### PR TITLE
Allow zero values for LRU config options

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -246,8 +246,8 @@ export class Appservice extends EventEmitter {
         options.joinStrategy = new AppserviceJoinRoomStrategy(options.joinStrategy, this);
 
         if (!options.intentOptions) options.intentOptions = {};
-        if (!options.intentOptions.maxAgeMs) options.intentOptions.maxAgeMs = 60 * 60 * 1000;
-        if (!options.intentOptions.maxCached) options.intentOptions.maxCached = 10000;
+        if (options.intentOptions.maxAgeMs === undefined) options.intentOptions.maxAgeMs = 60 * 60 * 1000;
+        if (options.intentOptions.maxCached === undefined) options.intentOptions.maxCached = 10000;
 
         this.intentsCache = new LRU({
             max: options.intentOptions.maxCached,


### PR DESCRIPTION
We'd like to disable the LRU to tempoarily workaround some caching issues, which requires us to be able to set the values of maxAgeMs/maxCached to `0`.
