### PR TITLE
Reduce our reliance on an up-to-date joined rooms cache

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -631,15 +631,15 @@ export class Appservice extends EventEmitter {
         const botDomain = new UserID(this.botUserId).domain;
         if (domain !== botDomain) return; // can't be impersonated, so don't try
 
-        // Update the target intent's joined rooms (fixes transition errors with the cache, like join->kick->join)
         const intent = this.getIntentForUserId(event['state_key']);
-        await intent.refreshJoinedRooms();
 
         const targetMembership = event["content"]["membership"];
         if (targetMembership === "join") {
+            intent.onRoomJoin(event["room_id"]);
             this.emit("room.join", event["room_id"], event);
             await intent.underlyingClient.crypto?.onRoomJoin(event["room_id"]);
         } else if (targetMembership === "ban" || targetMembership === "leave") {
+            intent.onRoomLeave(event["room_id"]);
             this.emit("room.leave", event["room_id"], event);
         } else if (targetMembership === "invite") {
             this.emit("room.invite", event["room_id"], event);

--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -635,11 +635,9 @@ export class Appservice extends EventEmitter {
 
         const targetMembership = event["content"]["membership"];
         if (targetMembership === "join") {
-            intent.onRoomJoin(event["room_id"]);
             this.emit("room.join", event["room_id"], event);
             await intent.underlyingClient.crypto?.onRoomJoin(event["room_id"]);
         } else if (targetMembership === "ban" || targetMembership === "leave") {
-            intent.onRoomLeave(event["room_id"]);
             this.emit("room.leave", event["room_id"], event);
         } else if (targetMembership === "invite") {
             this.emit("room.invite", event["room_id"], event);

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -256,6 +256,7 @@ export class Intent {
      * Ensures the user is joined to the given room
      * @param {string} roomId The room ID to join
      * @returns {Promise<any>} Resolves when complete
+     * @deprecated Use `joinRoom()` instead
      */
     @timedIntentFunctionCall()
     public async ensureJoined(roomId: string) {

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -190,6 +190,7 @@ export class Intent {
      */
     @timedIntentFunctionCall()
     public async getJoinedRooms(): Promise<string[]> {
+        await this.ensureRegistered();
         return await this.client.getJoinedRooms();
     }
 

--- a/test/appservice/AppserviceTest.ts
+++ b/test/appservice/AppserviceTest.ts
@@ -1752,7 +1752,7 @@ describe('Appservice', () => {
         };
 
         const intent = appservice.getIntentForSuffix("test");
-        intent.refreshJoinedRooms = () => Promise.resolve([]);
+        intent.getJoinedRooms = () => Promise.resolve([]);
 
         await appservice.begin();
 
@@ -1852,98 +1852,6 @@ describe('Appservice', () => {
 
             await doCall("/transactions/1", { json: txnBody });
             await doCall("/_matrix/app/v1/transactions/2", { json: txnBody });
-        } finally {
-            appservice.stop();
-        }
-    });
-
-    it('should refresh membership information of intents when actions are performed against them', async () => {
-        const port = await getPort();
-        const hsToken = "s3cret_token";
-        const appservice = new Appservice({
-            port: port,
-            bindAddress: '',
-            homeserverName: 'example.org',
-            homeserverUrl: 'https://localhost',
-            registration: {
-                as_token: "",
-                hs_token: hsToken,
-                sender_localpart: "_bot_",
-                namespaces: {
-                    users: [{ exclusive: true, regex: "@_prefix_.*:.+" }],
-                    rooms: [],
-                    aliases: [],
-                },
-            },
-        });
-        appservice.botIntent.ensureRegistered = () => {
-            return null;
-        };
-
-        await appservice.begin();
-
-        try {
-            const intent = appservice.getIntentForSuffix("test");
-            const refreshSpy = simple.stub().callFn(() => Promise.resolve([]));
-            intent.refreshJoinedRooms = refreshSpy;
-
-            // polyfill the dummy user too
-            const intent2 = appservice.getIntentForSuffix("test___WRONGUSER");
-            intent2.refreshJoinedRooms = () => Promise.resolve([]);
-
-            const joinTxn = {
-                events: [
-                    {
-                        type: "m.room.member",
-                        room_id: "!AAA:example.org",
-                        content: { membership: "join" },
-                        state_key: "@_prefix_test:example.org",
-                        sender: "@_prefix_test:example.org",
-                    },
-                    {
-                        type: "m.room.member",
-                        room_id: "!AAA:example.org",
-                        content: { membership: "join" },
-                        state_key: "@_prefix_test___WRONGUSER:example.org",
-                        sender: "@_prefix_test:example.org",
-                    },
-                ],
-            };
-            const kickTxn = {
-                events: [
-                    {
-                        type: "m.room.member",
-                        room_id: "!AAA:example.org",
-                        content: { membership: "leave" },
-                        state_key: "@_prefix_test:example.org",
-                        sender: "@someone_else:example.org",
-                    },
-                    {
-                        type: "m.room.member",
-                        room_id: "!AAA:example.org",
-                        content: { membership: "leave" },
-                        state_key: "@_prefix_test___WRONGUSER:example.org",
-                        sender: "@someone_else:example.org",
-                    },
-                ],
-            };
-
-            // eslint-disable-next-line no-inner-declarations
-            async function doCall(route: string, opts: any = {}) {
-                const res = await requestPromise({
-                    uri: `http://localhost:${port}${route}`,
-                    method: "PUT",
-                    qs: { access_token: hsToken },
-                    ...opts,
-                });
-                expect(res).toMatchObject({});
-
-                expect(refreshSpy.callCount).toBe(1);
-                refreshSpy.callCount = 0;
-            }
-
-            await doCall("/transactions/1", { json: joinTxn });
-            await doCall("/_matrix/app/v1/transactions/2", { json: kickTxn });
         } finally {
             appservice.stop();
         }

--- a/test/appservice/IntentTest.ts
+++ b/test/appservice/IntentTest.ts
@@ -267,274 +267,7 @@ describe('Intent', () => {
         });
     });
 
-    describe('getJoinedRooms', () => {
-        it('should fetch rooms if none are cached', async () => {
-            const userId = "@someone:example.org";
-            const botUserId = "@bot:example.org";
-            const asToken = "s3cret";
-            const hsUrl = "https://localhost";
-            const roomsPartA = ['!a:example.org', '!b:example.org'];
-            const appservice = <Appservice>{ botUserId: botUserId };
-            const storage = new MemoryStorageProvider();
-            const options = <IAppserviceOptions>{
-                homeserverUrl: hsUrl,
-                storage: <IAppserviceStorageProvider>storage,
-                registration: {
-                    as_token: asToken,
-                },
-            };
-
-            const intent = new Intent(options, userId, appservice);
-
-            const registeredSpy = simple.mock(intent, "ensureRegistered").callFn(() => {
-                return Promise.resolve();
-            });
-
-            const getJoinedSpy = simple.stub().callFn(() => {
-                return Promise.resolve(roomsPartA);
-            });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
-
-            const joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals(roomsPartA, joinedRooms);
-            expect(registeredSpy.callCount).toBe(1);
-            expect(getJoinedSpy.callCount).toBe(1);
-        });
-
-        it('should cache rooms on join', async () => {
-            const userId = "@someone:example.org";
-            const botUserId = "@bot:example.org";
-            const asToken = "s3cret";
-            const hsUrl = "https://localhost";
-            const roomId = "!test:example.org";
-            const appservice = <Appservice>{ botUserId: botUserId };
-            const storage = new MemoryStorageProvider();
-            const options = <IAppserviceOptions>{
-                homeserverUrl: hsUrl,
-                storage: <IAppserviceStorageProvider>storage,
-                registration: {
-                    as_token: asToken,
-                },
-            };
-
-            const intent = new Intent(options, userId, appservice);
-
-            const registeredSpy = simple.mock(intent, "ensureRegistered").callFn(() => {
-                return Promise.resolve();
-            });
-
-            const getJoinedSpy = simple.stub().callFn(() => {
-                if (getJoinedSpy.callCount === 1) return Promise.resolve([]);
-                return Promise.resolve([roomId]);
-            });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
-
-            const joinSpy = simple.stub().callFn((rid) => {
-                expect(rid).toBe(roomId);
-                return Promise.resolve(rid);
-            });
-            intent.underlyingClient.joinRoom = joinSpy;
-
-            let joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals([], joinedRooms);
-            expect(registeredSpy.callCount).toBe(1);
-            expect(getJoinedSpy.callCount).toBe(1);
-            expect(joinSpy.callCount).toBe(0);
-
-            await intent.joinRoom(roomId);
-
-            joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals([roomId], joinedRooms);
-            expect(registeredSpy.callCount).toBe(3);
-            expect(getJoinedSpy.callCount).toBe(2);
-            expect(joinSpy.callCount).toBe(1);
-        });
-
-        it('should cache rooms on leave', async () => {
-            const userId = "@someone:example.org";
-            const botUserId = "@bot:example.org";
-            const asToken = "s3cret";
-            const hsUrl = "https://localhost";
-            const roomId = "!test:example.org";
-            const appservice = <Appservice>{ botUserId: botUserId };
-            const storage = new MemoryStorageProvider();
-            const options = <IAppserviceOptions>{
-                homeserverUrl: hsUrl,
-                storage: <IAppserviceStorageProvider>storage,
-                registration: {
-                    as_token: asToken,
-                },
-            };
-
-            const intent = new Intent(options, userId, appservice);
-
-            const registeredSpy = simple.mock(intent, "ensureRegistered").callFn(() => {
-                return Promise.resolve();
-            });
-
-            const getJoinedSpy = simple.stub().callFn(() => {
-                if (getJoinedSpy.callCount > 1) return Promise.resolve([]);
-                return Promise.resolve([roomId]);
-            });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
-
-            const leaveSpy = simple.stub().callFn((rid) => {
-                expect(rid).toBe(roomId);
-                return Promise.resolve(rid);
-            });
-            intent.underlyingClient.leaveRoom = leaveSpy;
-
-            let joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals([roomId], joinedRooms);
-            expect(registeredSpy.callCount).toBe(1);
-            expect(getJoinedSpy.callCount).toBe(1);
-            expect(leaveSpy.callCount).toBe(0);
-
-            await intent.leaveRoom(roomId);
-
-            joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals([], joinedRooms);
-            expect(registeredSpy.callCount).toBe(3);
-            expect(getJoinedSpy.callCount).toBe(3);
-            expect(leaveSpy.callCount).toBe(1);
-        });
-
-        it('should cache rooms on ensureJoined', async () => {
-            const userId = "@someone:example.org";
-            const botUserId = "@bot:example.org";
-            const asToken = "s3cret";
-            const hsUrl = "https://localhost";
-            const roomId = "!test:example.org";
-            const appservice = <Appservice>{ botUserId: botUserId };
-            const storage = new MemoryStorageProvider();
-            const options = <IAppserviceOptions>{
-                homeserverUrl: hsUrl,
-                storage: <IAppserviceStorageProvider>storage,
-                registration: {
-                    as_token: asToken,
-                },
-            };
-
-            const intent = new Intent(options, userId, appservice);
-
-            const registeredSpy = simple.mock(intent, "ensureRegistered").callFn(() => {
-                return Promise.resolve();
-            });
-
-            const getJoinedSpy = simple.stub().callFn(() => {
-                if (getJoinedSpy.callCount <= 2) return Promise.resolve([]);
-                return Promise.resolve([roomId]);
-            });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
-
-            const joinSpy = simple.stub().callFn((rid) => {
-                expect(rid).toBe(roomId);
-                return Promise.resolve(rid);
-            });
-            intent.underlyingClient.joinRoom = joinSpy;
-
-            let joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals([], joinedRooms);
-            expect(registeredSpy.callCount).toBe(1);
-            expect(getJoinedSpy.callCount).toBe(1);
-            expect(joinSpy.callCount).toBe(0);
-
-            await intent.ensureJoined(roomId);
-
-            joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals([roomId], joinedRooms);
-            expect(registeredSpy.callCount).toBe(2);
-            expect(getJoinedSpy.callCount).toBe(2);
-            expect(joinSpy.callCount).toBe(1);
-
-            // Duplicate just to prove it caches it
-            await intent.ensureJoined(roomId);
-
-            joinedRooms = await intent.getJoinedRooms();
-            expectArrayEquals([roomId], joinedRooms);
-            expect(registeredSpy.callCount).toBe(3);
-            expect(getJoinedSpy.callCount).toBe(2);
-            expect(joinSpy.callCount).toBe(1);
-        });
-    });
-
-    describe('refreshJoinedRooms', () => {
-        it('should overwrite any previously known joined rooms', async () => {
-            const userId = "@someone:example.org";
-            const botUserId = "@bot:example.org";
-            const asToken = "s3cret";
-            const hsUrl = "https://localhost";
-            const roomsPartA = ['!a:example.org', '!b:example.org'];
-            const roomsPartB = ['!c:example.org', '!d:example.org'];
-            const appservice = <Appservice>{ botUserId: botUserId };
-            const storage = new MemoryStorageProvider();
-            const options = <IAppserviceOptions>{
-                homeserverUrl: hsUrl,
-                storage: <IAppserviceStorageProvider>storage,
-                registration: {
-                    as_token: asToken,
-                },
-            };
-
-            const intent = new Intent(options, userId, appservice);
-
-            // We have to do private access to ensure that the intent actually overwrites
-            // its cache.
-            const getJoinedRooms = () => (<any>intent).knownJoinedRooms;
-            const setJoinedRooms = (rooms) => (<any>intent).knownJoinedRooms = rooms;
-
-            const getJoinedSpy = simple.stub().callFn(() => {
-                return Promise.resolve(roomsPartB);
-            });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
-
-            // Do a quick assert to prove that our private access hooks work
-            expectArrayEquals([], getJoinedRooms());
-            setJoinedRooms(roomsPartA);
-            expectArrayEquals(roomsPartA, getJoinedRooms());
-
-            const result = await intent.refreshJoinedRooms();
-            expect(getJoinedSpy.callCount).toBe(1);
-            expectArrayEquals(roomsPartB, result);
-            expectArrayEquals(roomsPartB, getJoinedRooms());
-        });
-    });
-
     describe('ensureJoined', () => {
-        it('should fetch the rooms the user is joined to', async () => {
-            const userId = "@someone:example.org";
-            const botUserId = "@bot:example.org";
-            const asToken = "s3cret";
-            const hsUrl = "https://localhost";
-            const roomIds = ["!a:example.org", "!b:example.org"];
-            const targetRoomId = "!a:example.org";
-            const appservice = <Appservice>{ botUserId: botUserId };
-            const storage = new MemoryStorageProvider();
-            const options = <IAppserviceOptions>{
-                homeserverUrl: hsUrl,
-                storage: <IAppserviceStorageProvider>storage,
-                registration: {
-                    as_token: asToken,
-                },
-            };
-
-            const intent = new Intent(options, userId, appservice);
-
-            const getJoinedSpy = simple.stub().callFn(() => {
-                return Promise.resolve(roomIds);
-            });
-            const joinSpy = simple.stub().callFn((rid) => {
-                expect(rid).toEqual(targetRoomId);
-                return Promise.resolve("!joined:example.org");
-            });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
-            intent.underlyingClient.joinRoom = joinSpy;
-
-            await intent.ensureJoined(targetRoomId);
-            expect(getJoinedSpy.callCount).toBe(1);
-            expect(joinSpy.callCount).toBe(0);
-        });
-
         it('should attempt to join rooms a user is not in', async () => {
             const userId = "@someone:example.org";
             const botUserId = "@bot:example.org";
@@ -554,18 +287,13 @@ describe('Intent', () => {
 
             const intent = new Intent(options, userId, appservice);
 
-            const getJoinedSpy = simple.stub().callFn(() => {
-                return Promise.resolve(roomIds);
-            });
             const joinSpy = simple.stub().callFn((rid) => {
                 expect(rid).toEqual(targetRoomId);
                 return Promise.resolve("!joined:example.org");
             });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
             intent.underlyingClient.joinRoom = joinSpy;
 
             await intent.ensureJoined(targetRoomId);
-            expect(getJoinedSpy.callCount).toBe(1);
             expect(joinSpy.callCount).toBe(1);
         });
 
@@ -588,14 +316,10 @@ describe('Intent', () => {
 
             const intent = new Intent(options, userId, appservice);
 
-            const getJoinedSpy = simple.stub().callFn(() => {
-                return Promise.resolve(roomIds);
-            });
             const joinSpy = simple.stub().callFn((rid) => {
                 expect(rid).toEqual(targetRoomId);
                 throw new Error("Simulated failure");
             });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
             intent.underlyingClient.joinRoom = joinSpy;
 
             try {
@@ -606,48 +330,7 @@ describe('Intent', () => {
             } catch (e) {
                 expect(e.message).toEqual("Simulated failure");
             }
-            expect(getJoinedSpy.callCount).toBe(1);
             expect(joinSpy.callCount).toBe(1);
-        });
-
-        it('should proxy failure for getting joined rooms', async () => {
-            const userId = "@someone:example.org";
-            const botUserId = "@bot:example.org";
-            const asToken = "s3cret";
-            const hsUrl = "https://localhost";
-            const targetRoomId = "!c:example.org";
-            const appservice = <Appservice>{ botUserId: botUserId };
-            const storage = new MemoryStorageProvider();
-            const options = <IAppserviceOptions>{
-                homeserverUrl: hsUrl,
-                storage: <IAppserviceStorageProvider>storage,
-                registration: {
-                    as_token: asToken,
-                },
-            };
-
-            const intent = new Intent(options, userId, appservice);
-
-            const getJoinedSpy = simple.stub().callFn(() => {
-                throw new Error("Simulated failure");
-            });
-            const joinSpy = simple.stub().callFn((rid) => {
-                expect(rid).toEqual(targetRoomId);
-                return Promise.resolve("!joined:example.org");
-            });
-            intent.underlyingClient.getJoinedRooms = getJoinedSpy;
-            intent.underlyingClient.joinRoom = joinSpy;
-
-            try {
-                await intent.ensureJoined(targetRoomId);
-
-                // noinspection ExceptionCaughtLocallyJS
-                throw new Error("Request completed when it should have failed");
-            } catch (e) {
-                expect(e.message).toEqual("Simulated failure");
-            }
-            expect(getJoinedSpy.callCount).toBe(1);
-            expect(joinSpy.callCount).toBe(0);
         });
     });
 
@@ -968,23 +651,17 @@ describe('Intent', () => {
                 expect(rid).toEqual(targetRoomId);
                 return {};
             });
-            const refreshJoinedRoomsSpy = simple.stub().callFn(() => {
-                return Promise.resolve([]);
-            });
-
             const joinRoomSpy = simple.stub().callFn((rid) => {
                 expect(rid).toEqual(targetRoomId);
                 return Promise.resolve(targetRoomId);
             });
             intent.underlyingClient.joinRoom = joinRoomSpy;
-            intent.refreshJoinedRooms = refreshJoinedRoomsSpy;
 
             const result = await intent.joinRoom(targetRoomId);
             expect(result).toEqual(targetRoomId);
             expect(joinRoomSpy.callCount).toBe(1);
             expect(registeredSpy.callCount).toBe(1);
             expect(joinSpy.callCount).toBe(0);
-            expect(refreshJoinedRoomsSpy.callCount).toBe(1);
         });
 
         it('should proxy errors upwards', async () => {
@@ -1059,22 +736,17 @@ describe('Intent', () => {
                 expect(rid).toEqual(targetRoomId);
                 return {};
             });
-            const refreshJoinedRoomsSpy = simple.stub().callFn(() => {
-                return Promise.resolve([]);
-            });
 
             const leaveRoomSpy = simple.stub().callFn((rid) => {
                 expect(rid).toEqual(targetRoomId);
                 return Promise.resolve(targetRoomId);
             });
             intent.underlyingClient.leaveRoom = leaveRoomSpy;
-            intent.refreshJoinedRooms = refreshJoinedRoomsSpy;
 
             await intent.leaveRoom(targetRoomId);
             expect(leaveRoomSpy.callCount).toBe(1);
             expect(registeredSpy.callCount).toBe(1);
             expect(joinSpy.callCount).toBe(0);
-            expect(refreshJoinedRoomsSpy.callCount).toBe(1);
         });
 
         it('should proxy errors upwards', async () => {

--- a/test/appservice/IntentTest.ts
+++ b/test/appservice/IntentTest.ts
@@ -3,7 +3,6 @@ import HttpBackend from 'matrix-mock-request';
 import * as tmp from "tmp";
 import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
 
-import { expectArrayEquals } from "../TestUtils";
 import {
     Appservice,
     IAppserviceCryptoStorageProvider,
@@ -274,7 +273,6 @@ describe('Intent', () => {
             const botUserId = "@bot:example.org";
             const asToken = "s3cret";
             const hsUrl = "https://localhost";
-            const roomIds = ["!a:example.org", "!b:example.org"];
             const targetRoomId = "!c:example.org";
             const appservice = <Appservice>{ botUserId: botUserId };
             const storage = new MemoryStorageProvider();
@@ -303,7 +301,6 @@ describe('Intent', () => {
             const botUserId = "@bot:example.org";
             const asToken = "s3cret";
             const hsUrl = "https://localhost";
-            const roomIds = ["!a:example.org", "!b:example.org"];
             const targetRoomId = "!c:example.org";
             const appservice = <Appservice>{ botUserId: botUserId };
             const storage = new MemoryStorageProvider();


### PR DESCRIPTION
Opening this mostly to start a discussion and see how best to proceed with this.

The current joined rooms API is not very safe by default. It caches joined rooms to allegedly to speed up `ensureRoomJoined()` ([comment](https://github.com/vector-im/matrix-bot-sdk/blob/11f39627ced1d836abbc3cf8c13fe4f31861c78c/src/appservice/Intent.ts#LL291C15-L291C15)), but also utilizes it in other ways, like [ignoring some room events in crypto handling if it doesn't think the user is in a certain room](https://github.com/vector-im/matrix-bot-sdk/blob/11f39627ced1d836abbc3cf8c13fe4f31861c78c/src/appservice/Intent.ts#L175) – making the invalid cache a potential source of bugs.

Different API calls like `Intent.getJoinedRooms()` ([here](https://github.com/vector-im/matrix-bot-sdk/blob/11f39627ced1d836abbc3cf8c13fe4f31861c78c/src/appservice/Intent.ts#L189)) warn that joining rooms out of band may cause the Intent API to return incorrect results. To help with that, it exposes a public API to refresh its own cache (`Intent.refreshJoinedRooms()` [here](https://github.com/vector-im/matrix-bot-sdk/blob/11f39627ced1d836abbc3cf8c13fe4f31861c78c/src/appservice/Intent.ts#L296)). The necessity to call this at the right times comes with its own problems, like Appservice membership event handling [possibly failing](https://github.com/vector-im/matrix-bot-sdk/blob/11f39627ced1d836abbc3cf8c13fe4f31861c78c/src/appservice/Appservice.ts#L634) due to triggering Matrix API calls when it doesn't need to. There's a few places where we refresh the entire joined room list rather than applying the membership changes that we know have just happened, which I fixed in this PR.

I don't think the worry about externally induced joins not being noticed by the bot-sdk are entirely warranted (we're bound to get the room joined AS event first after all, I don't think there's any way we can miss it even if we didn't trigger it), but this whole mechanism seems like an optimization both premature (joining an already joined room excessively is not an error, and I imagine is pretty cheap) and happening at the wrong layer. The user of the SDK can make a more informed decision if, in their scope, it makes sense to cache such things, or if it's safe to use at all.

---

This PR slightly reduces our reliance of the joined rooms cache – never making decisions like "should we drop this event" based on its contents, and making public APIs like `getJoinedRooms()` return freshest possible information anyway. `refreshJoinedRooms()` should probably be deprecated here, but I do wonder if a proper solution would be just dropping this whole caching from Intent and leaving it up to the SDK user to decide whether they need something like that or not. It is, after all, trivial to implement yourself – I've done just that in my projects, not knowing that `ensureRoomJoined()` does the caching by itself.