### PR TITLE
Correct the output folder for the Docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,4 +17,4 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
-        folder: .jsdoc/matrix-bot-sdk/develop
+        folder: .jsdoc/@vector-im/matrix-bot-sdk/develop


### PR DESCRIPTION
This should fix [the Docs workflow](https://github.com/vector-im/matrix-bot-sdk/actions/workflows/docs.yml) after having renamed the default branch from `element-main` to just `main`.

And, since the workflow gets triggered on pushes to `main` (and always has), the branch name change means that we'll now build docs for our fork instead of rebuilding upstream's docs.