### PR TITLE
Pull to-device event list out of returned tuple

### DIFF
--- a/examples/bot.ts
+++ b/examples/bot.ts
@@ -27,7 +27,7 @@ const dmTarget = creds?.['dmTarget'] ?? "@admin:localhost";
 const homeserverUrl = creds?.['homeserverUrl'] ?? "http://localhost:8008";
 const accessToken = creds?.['accessToken'] ?? 'YOUR_TOKEN';
 const storage = new SimpleFsStorageProvider("./examples/storage/bot.json");
-const crypto = new RustSdkCryptoStorageProvider("./examples/storage/bot_sled", StoreType.Sled);
+const crypto = new RustSdkCryptoStorageProvider("./examples/storage/bot_sqlite", StoreType.Sqlite);
 
 const client = new MatrixClient(homeserverUrl, accessToken, storage, crypto);
 AutojoinRoomsMixin.setupOnClient(client);

--- a/examples/encryption_appservice.ts
+++ b/examples/encryption_appservice.ts
@@ -31,7 +31,7 @@ try {
 const dmTarget = creds?.['dmTarget'] ?? "@admin:localhost";
 const homeserverUrl = creds?.['homeserverUrl'] ?? "http://localhost:8008";
 const storage = new SimpleFsStorageProvider("./examples/storage/encryption_appservice.json");
-const crypto = new RustSdkAppserviceCryptoStorageProvider("./examples/storage/encryption_appservice_sled", StoreType.Sled);
+const crypto = new RustSdkAppserviceCryptoStorageProvider("./examples/storage/encryption_appservice_sqlite", StoreType.Sqlite);
 const worksImage = fs.readFileSync("./examples/static/it-works.png");
 
 const registration: IAppserviceRegistration = {

--- a/examples/encryption_bot.ts
+++ b/examples/encryption_bot.ts
@@ -29,7 +29,7 @@ const dmTarget = creds?.['dmTarget'] ?? "@admin:localhost";
 const homeserverUrl = creds?.['homeserverUrl'] ?? "http://localhost:8008";
 const accessToken = creds?.['accessToken'] ?? 'YOUR_TOKEN';
 const storage = new SimpleFsStorageProvider("./examples/storage/encryption_bot.json");
-const crypto = new RustSdkCryptoStorageProvider("./examples/storage/encryption_bot_sled", StoreType.Sled);
+const crypto = new RustSdkCryptoStorageProvider("./examples/storage/encryption_bot_sqlite", StoreType.Sqlite);
 const worksImage = fs.readFileSync("./examples/static/it-works.png");
 
 const client = new MatrixClient(homeserverUrl, accessToken, storage, crypto);

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tsconfig.json"
   ],
   "dependencies": {
-    "@matrix-org/matrix-sdk-crypto-nodejs": "0.1.0-beta.6",
+    "@matrix-org/matrix-sdk-crypto-nodejs": "0.1.0-beta.9",
     "@types/express": "^4.17.13",
     "another-json": "^0.2.0",
     "async-lock": "^1.3.2",

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -169,13 +169,12 @@ export class CryptoClient {
 
         await this.engine.lock.acquire(SYNC_LOCK_NAME, async () => {
             const syncResp = JSON.parse(await this.engine.machine.receiveSyncChanges(deviceMessages, deviceLists, otkCounts, unusedFallbackKeyAlgs));
-            if (Array.isArray(syncResp)) {
-                const decryptedToDeviceMessages = syncResp[0];
-                if (Array.isArray(decryptedToDeviceMessages)) {
-                    for (const msg of decryptedToDeviceMessages as IToDeviceMessage[]) {
-                        this.client.emit("to_device.decrypted", msg);
-                    }
+            if (Array.isArray(syncResp) && syncResp.length === 2 && Array.isArray(syncResp[0])) {
+                for (const msg of syncResp[0] as IToDeviceMessage[]) {
+                    this.client.emit("to_device.decrypted", msg);
                 }
+            } else {
+                LogService.error("CryptoClient", "OlmMachine.receiveSyncChanges did not return an expected value of [to-device events, room key changes]");
             }
 
             await this.engine.run();

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -168,11 +168,13 @@ export class CryptoClient {
             leftDeviceLists.map(u => new UserId(u)));
 
         await this.engine.lock.acquire(SYNC_LOCK_NAME, async () => {
-            const syncResp = await this.engine.machine.receiveSyncChanges(deviceMessages, deviceLists, otkCounts, unusedFallbackKeyAlgs);
-            const decryptedToDeviceMessages = JSON.parse(syncResp);
-            if (Array.isArray(decryptedToDeviceMessages)) {
-                for (const msg of decryptedToDeviceMessages) {
-                    this.client.emit("to_device.decrypted", msg);
+            const syncResp = JSON.parse(await this.engine.machine.receiveSyncChanges(deviceMessages, deviceLists, otkCounts, unusedFallbackKeyAlgs));
+            if (Array.isArray(syncResp)) {
+                const decryptedToDeviceMessages = syncResp[0];
+                if (Array.isArray(decryptedToDeviceMessages)) {
+                    for (const msg of decryptedToDeviceMessages as IToDeviceMessage[]) {
+                        this.client.emit("to_device.decrypted", msg);
+                    }
                 }
             }
 

--- a/src/storage/RustSdkCryptoStorageProvider.ts
+++ b/src/storage/RustSdkCryptoStorageProvider.ts
@@ -26,7 +26,7 @@ export class RustSdkCryptoStorageProvider implements ICryptoStorageProvider {
      */
     public constructor(
         public readonly storagePath: string,
-        public readonly storageType: RustSdkCryptoStoreType = RustSdkCryptoStoreType.Sled,
+        public readonly storageType: RustSdkCryptoStoreType = RustSdkCryptoStoreType.Sqlite,
     ) {
         this.storagePath = path.resolve(this.storagePath);
         mkdirp.sync(storagePath);
@@ -69,7 +69,7 @@ export class RustSdkAppserviceCryptoStorageProvider extends RustSdkCryptoStorage
      * @param baseStoragePath The *directory* to persist database details to.
      * @param storageType The storage type to use. Must be supported by the rust-sdk.
      */
-    public constructor(private baseStoragePath: string, storageType: RustSdkCryptoStoreType = RustSdkCryptoStoreType.Sled) {
+    public constructor(private baseStoragePath: string, storageType: RustSdkCryptoStoreType = RustSdkCryptoStoreType.Sqlite) {
         super(path.join(baseStoragePath, "_default"), storageType);
     }
 

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -1400,8 +1400,7 @@ describe('MatrixClient', () => {
     describe('processSync', () => {
         interface ProcessSyncClient {
             userId: string;
-
-            processSync(raw: any): Promise<any>;
+            processSync(raw: any): MatrixClient["processSync"];
         }
 
         it('should process non-room account data', async () => {

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -1,6 +1,5 @@
 import * as tmp from "tmp";
 import * as simple from "simple-mock";
-import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
 
 import {
     EventKind,
@@ -48,13 +47,13 @@ describe('MatrixClient', () => {
             expect(client.accessToken).toEqual(accessToken);
         });
 
-        it('should create a crypto client when requested', () => {
+        it('should create a crypto client when requested', () => testCryptoStores(async (cryptoStoreType) => {
             const homeserverUrl = "https://example.org";
             const accessToken = "example_token";
 
-            const client = new MatrixClient(homeserverUrl, accessToken, null, new RustSdkCryptoStorageProvider(tmp.dirSync().name, StoreType.Sled));
+            const client = new MatrixClient(homeserverUrl, accessToken, null, new RustSdkCryptoStorageProvider(tmp.dirSync().name, cryptoStoreType));
             expect(client.crypto).toBeDefined();
-        });
+        }));
 
         it('should NOT create a crypto client when requested', () => {
             const homeserverUrl = "https://example.org";

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -47,7 +47,7 @@ export function createTestClient(
     return { http, hsUrl, accessToken, client };
 }
 
-const CRYPTO_STORE_TYPES = [StoreType.Sled, StoreType.Sqlite];
+const CRYPTO_STORE_TYPES = [StoreType.Sqlite];
 
 export async function testCryptoStores(fn: (StoreType) => Promise<void>): Promise<void> {
     for (const st of CRYPTO_STORE_TYPES) {

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -40,14 +40,14 @@ export function createTestClient(
     const http = new HttpBackend();
     const hsUrl = "https://localhost";
     const accessToken = "s3cret";
-    const client = new MatrixClient(hsUrl, accessToken, storage, cryptoStoreType !== undefined ? new RustSdkCryptoStorageProvider(tmp.dirSync().name, cryptoStoreType) : null);
+    const client = new MatrixClient(hsUrl, accessToken, storage, (cryptoStoreType !== undefined) ? new RustSdkCryptoStorageProvider(tmp.dirSync().name, cryptoStoreType) : null);
     (<any>client).userId = userId; // private member access
     setRequestFn(http.requestFn);
 
     return { http, hsUrl, accessToken, client };
 }
 
-const CRYPTO_STORE_TYPES = [StoreType.Sqlite];
+const CRYPTO_STORE_TYPES: StoreType[] = [StoreType.Sqlite];
 
 export async function testCryptoStores(fn: (StoreType) => Promise<void>): Promise<void> {
     for (const st of CRYPTO_STORE_TYPES) {

--- a/test/appservice/IntentTest.ts
+++ b/test/appservice/IntentTest.ts
@@ -1137,7 +1137,7 @@ describe('Intent', () => {
 
         beforeEach(() => {
             storage = new MemoryStorageProvider();
-            cryptoStorage = new RustSdkAppserviceCryptoStorageProvider(tmp.dirSync().name, StoreType.Sled);
+            cryptoStorage = new RustSdkAppserviceCryptoStorageProvider(tmp.dirSync().name, StoreType.Sqlite);
             options = {
                 homeserverUrl: hsUrl,
                 storage: storage,

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,10 +584,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@matrix-org/matrix-sdk-crypto-nodejs@0.1.0-beta.6":
-  version "0.1.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.1.0-beta.6.tgz#0ecae51103ee3c107af0d6d0738f33eb7cc9857e"
-  integrity sha512-JXyrHuCVMydUGgSetWsfqbbvHj3aUMOX5TUghlMtLFromyEu7wIsNgYt7PjJ+k3WdF4GVABRy4P6GNjaEMy2uA==
+"@matrix-org/matrix-sdk-crypto-nodejs@0.1.0-beta.9":
+  version "0.1.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.1.0-beta.9.tgz#dc21f3b0f4b35b73befc64a257b8e519afbcbed0"
+  integrity sha512-ee2YlBoXPLgp1aav9MqREJKvWJfURn9Jcs46FyWT4NXEl37KQDNC8CWWnqgqsHkLfBxxSxfq9kMA/mWQZF7QJw==
   dependencies:
     https-proxy-agent "^5.0.1"
     node-downloader-helper "^2.1.5"


### PR DESCRIPTION
OlmMachine.receiveSyncChanges returns an array of [device messages, room key changes], so emit "to_device.decrypted" with that instead of the entire array.

Fixes regression introduced by #287.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
