### PR TITLE
Tweak key backup auth data type to fix docs

### DIFF
--- a/src/models/KeyBackup.ts
+++ b/src/models/KeyBackup.ts
@@ -14,13 +14,15 @@ export interface ICurve25519AuthDataUnsigned {
 }
 export type ICurve25519AuthData = ICurve25519AuthDataUnsigned & Signed;
 
+export type IKeyBackupAuthData = IJsonType | ICurve25519AuthDataUnsigned;
+
 /**
  * Information about a server-side key backup,
  * with its auth_data left unsigned.
  */
 export interface IKeyBackupInfoUnsigned {
     algorithm: string | KeyBackupEncryptionAlgorithm;
-    auth_data: IJsonType | ICurve25519AuthDataUnsigned;
+    auth_data: IKeyBackupAuthData;
 }
 
 /**
@@ -28,7 +30,7 @@ export interface IKeyBackupInfoUnsigned {
  * with its auth_data signed by the entity that created it.
  */
 export type IKeyBackupInfo = IKeyBackupInfoUnsigned & {
-    auth_data: Signed & IKeyBackupInfoUnsigned["auth_data"];
+    auth_data: Signed & IKeyBackupAuthData;
 };
 
 export type KeyBackupVersion = string;


### PR DESCRIPTION
Without this, `yarn docs` fails on parsing an [indexed type](https://www.typescriptlang.org/docs/handbook/2/indexed-access-types.html): https://github.com/vector-im/matrix-bot-sdk/actions/runs/5826217511/job/15799640682#step:5:55

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
