### PR TITLE
Get type checking from OlmMachine.shareRoomKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tsconfig.json"
   ],
   "dependencies": {
-    "@matrix-org/matrix-sdk-crypto-nodejs": "0.1.0-beta.9",
+    "@matrix-org/matrix-sdk-crypto-nodejs": "0.1.0-beta.10",
     "@types/express": "^4.17.13",
     "another-json": "^0.2.0",
     "async-lock": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,10 +584,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@matrix-org/matrix-sdk-crypto-nodejs@0.1.0-beta.9":
-  version "0.1.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.1.0-beta.9.tgz#dc21f3b0f4b35b73befc64a257b8e519afbcbed0"
-  integrity sha512-ee2YlBoXPLgp1aav9MqREJKvWJfURn9Jcs46FyWT4NXEl37KQDNC8CWWnqgqsHkLfBxxSxfq9kMA/mWQZF7QJw==
+"@matrix-org/matrix-sdk-crypto-nodejs@0.1.0-beta.10":
+  version "0.1.0-beta.10"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.1.0-beta.10.tgz#52290c76ac997001b615c9fb78b70e36b6a4501f"
+  integrity sha512-AiSHgpHw75sJ1k9uqWk74Wps74XM+M7LsQZrLFlZh/nv9fhOk7JvRZlQczDK9qhD0Umt84PRcOumgT5bXbA/lw==
   dependencies:
     https-proxy-agent "^5.0.1"
     node-downloader-helper "^2.1.5"


### PR DESCRIPTION
Update the rust-sdk bindings to have access to type checking in the return value of OlmMachine.shareRoomKey, which now returns an array of ToDeviceRequest objects instead of a JSON encoding of the whole array.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
