### PR TITLE
Emit an event when an Intent is created

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -451,6 +451,7 @@ export class Appservice extends EventEmitter {
         let intent: Intent = this.intentsCache.get(userId);
         if (!intent) {
             intent = new Intent(this.options, userId, this);
+            this.emit("intent.new", intent);
             this.intentsCache.set(userId, intent);
             if (this.options.intentOptions.encryption) {
                 intent.enableEncryption().catch(e => {


### PR DESCRIPTION
This allows responding to when a transaction requires an appservice user that the process has not yet initialized.

## Checklist

* [ ] Tests written for all new code
  * not writing a test for this tiny change
* [x] Linter has been satisfied
