### PR TITLE
Listen for intent setup

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -451,8 +451,8 @@ export class Appservice extends EventEmitter {
         let intent: Intent = this.intentsCache.get(userId);
         if (!intent) {
             intent = new Intent(this.options, userId, this);
-            this.emit("intent.new", intent);
             this.intentsCache.set(userId, intent);
+            this.emit("intent.new", intent);
             if (this.options.intentOptions.encryption) {
                 intent.enableEncryption().catch(e => {
                     LogService.error("Appservice", `Failed to set up crypto on intent ${userId}`, e);


### PR DESCRIPTION
Otherwise, if a listener of that event were to trigger a lookup of the same Intent, the lookup wouldn't see the event in the Intent cache, and thus cause a new Intent to be created & new event to be emitted.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
