### PR TITLE
Cache non-encrypted rooms and skip fetching encrypted rooms on startup

### DIFF
--- a/examples/encryption_bot.ts
+++ b/examples/encryption_bot.ts
@@ -35,9 +35,9 @@ const worksImage = fs.readFileSync("./examples/static/it-works.png");
 const client = new MatrixClient(homeserverUrl, accessToken, storage, crypto);
 
 (async function() {
-    let encryptedRoomId: string;
+    let encryptedRoomId: string|undefined = undefined;
     const joinedRooms = await client.getJoinedRooms();
-    await client.crypto.prepare(joinedRooms); // init crypto because we're doing things before the client is started
+    await client.crypto.prepare(); // init crypto because we're doing things before the client is started
     for (const roomId of joinedRooms) {
         if (await client.crypto.isRoomEncrypted(roomId)) {
             encryptedRoomId = roomId;

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -656,7 +656,7 @@ export class MatrixClient extends EventEmitter {
 
         if (this.crypto) {
             LogService.debug("MatrixClientLite", "Preparing end-to-end encryption");
-            await this.crypto.prepare(this.lastJoinedRoomIds);
+            await this.crypto.prepare();
             LogService.info("MatrixClientLite", "End-to-end encryption enabled");
         }
 

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -168,7 +168,7 @@ export class Intent {
                     }
 
                     // Now set up crypto
-                    await this.client.crypto.prepare(await this.getJoinedRooms());
+                    await this.client.crypto.prepare();
 
                     this.appservice.on("room.event", (roomId, event) => {
                         this.client.crypto.onRoomEvent(roomId, event);

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -117,6 +117,8 @@ export class CryptoClient {
             if (membership.effectiveMembership !== 'join' && membership.effectiveMembership !== 'invite') return;
             await this.engine.addTrackedUsers([membership.membershipFor]);
         } else if (event['type'] === 'm.room.encryption') {
+            // Update encryption status of room.
+            await this.roomTracker.queueRoomCheck(roomId);
             return this.client.getRoomMembers(roomId, null, ['join', 'invite']).then(
                 members => this.engine.addTrackedUsers(members.map(e => e.membershipFor)),
                 e => void LogService.warn("CryptoClient", `Unable to get members of room ${roomId}`),

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -115,8 +115,6 @@ export class CryptoClient {
             if (membership.effectiveMembership !== 'join' && membership.effectiveMembership !== 'invite') return;
             await this.engine.addTrackedUsers([membership.membershipFor]);
         } else if (event['type'] === 'm.room.encryption') {
-            // Update encryption status of room.
-            await this.roomTracker.queueRoomCheck(roomId);
             return this.client.getRoomMembers(roomId, null, ['join', 'invite']).then(
                 members => this.engine.addTrackedUsers(members.map(e => e.membershipFor)),
                 e => void LogService.warn("CryptoClient", `Unable to get members of room ${roomId}`),

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -68,9 +68,7 @@ export class CryptoClient {
      * Prepares the crypto client for usage.
      * @param {string[]} roomIds The room IDs the MatrixClient is joined to.
      */
-    public async prepare(roomIds: string[]) {
-        await this.roomTracker.prepare(roomIds);
-
+    public async prepare() {
         if (this.ready) return; // stop re-preparing here
 
         const storedDeviceId = await this.client.cryptoStore.getDeviceId();

--- a/src/e2ee/RoomTracker.ts
+++ b/src/e2ee/RoomTracker.ts
@@ -63,12 +63,9 @@ export class RoomTracker {
             encEvent.algorithm = encEvent.algorithm ?? 'UNKNOWN';
         } catch (e) {
             if (e instanceof MatrixError && e.errcode === "M_NOT_FOUND") {
-                // No encryption
                 encEvent = {};
-            } else {
-                // Unexpected failure, do not store.
-                return;
             }
+            return; // Other failures should not be cached.
         }
 
         // Pick out the history visibility setting too

--- a/src/e2ee/RoomTracker.ts
+++ b/src/e2ee/RoomTracker.ts
@@ -1,4 +1,5 @@
 import { MatrixClient } from "../MatrixClient";
+import { MatrixError } from "../models/MatrixError";
 import { EncryptionEventContent } from "../models/events/EncryptionEvent";
 import { ICryptoRoomInformation } from "./ICryptoRoomInformation";
 
@@ -61,7 +62,13 @@ export class RoomTracker {
             encEvent = await this.client.getRoomStateEvent(roomId, "m.room.encryption", "");
             encEvent.algorithm = encEvent.algorithm ?? 'UNKNOWN';
         } catch (e) {
-            return; // failure == no encryption
+            if (e instanceof MatrixError && e.errcode === "M_NOT_FOUND") {
+                // No encryption
+                encEvent = {};
+            } else {
+                // Unexpected failure, do not store.
+                return;
+            }
         }
 
         // Pick out the history visibility setting too

--- a/src/e2ee/RoomTracker.ts
+++ b/src/e2ee/RoomTracker.ts
@@ -54,8 +54,9 @@ export class RoomTracker {
         } catch (e) {
             if (e instanceof MatrixError && e.errcode === "M_NOT_FOUND") {
                 encEvent = {};
+            } else {
+                return; // Other failures should not be cached.
             }
-            return; // Other failures should not be cached.
         }
 
         // Pick out the history visibility setting too

--- a/src/e2ee/RoomTracker.ts
+++ b/src/e2ee/RoomTracker.ts
@@ -35,16 +35,6 @@ export class RoomTracker {
     }
 
     /**
-     * Prepares the room tracker to track the given rooms.
-     * @param {string[]} roomIds The room IDs to track. This should be the joined rooms set.
-     */
-    public async prepare(roomIds: string[]) {
-        for (const roomId of roomIds) {
-            await this.queueRoomCheck(roomId);
-        }
-    }
-
-    /**
      * Queues a room check for the tracker. If the room needs an update to the store, an
      * update will be made.
      * @param {string} roomId The room ID to check.

--- a/test/encryption/CryptoClientTest.ts
+++ b/test/encryption/CryptoClientTest.ts
@@ -34,7 +34,7 @@ describe('CryptoClient', () => {
 
             bindNullEngine(http);
             // Prepare first
-            await Promise.all([,
+            await Promise.all([
                 client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);

--- a/test/encryption/CryptoClientTest.ts
+++ b/test/encryption/CryptoClientTest.ts
@@ -17,7 +17,7 @@ describe('CryptoClient', () => {
 
         bindNullEngine(http);
         await Promise.all([
-            client.crypto.prepare([]),
+            client.crypto.prepare(),
             http.flushAllExpected(),
         ]);
 
@@ -28,24 +28,17 @@ describe('CryptoClient', () => {
     describe('prepare', () => {
         it('should prepare the room tracker', () => testCryptoStores(async (cryptoStoreType) => {
             const userId = "@alice:example.org";
-            const roomIds = ["!a:example.org", "!b:example.org"];
             const { client, http } = createTestClient(null, userId, cryptoStoreType);
 
             client.getWhoAmI = () => Promise.resolve({ user_id: userId, device_id: TEST_DEVICE_ID });
 
-            const prepareSpy = simple.stub().callFn((rids: string[]) => {
-                expect(rids).toBe(roomIds);
-                return Promise.resolve();
-            });
-
-            (<any>client.crypto).roomTracker.prepare = prepareSpy; // private member access
-
             bindNullEngine(http);
-            await Promise.all([
-                client.crypto.prepare(roomIds),
+            // Prepare first
+            await Promise.all([,
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
-            expect(prepareSpy.callCount).toEqual(1);
+            expect(client.crypto.isReady).toBe(true);
         }));
 
         it('should use a stored device ID', () => testCryptoStores(async (cryptoStoreType) => {
@@ -59,7 +52,7 @@ describe('CryptoClient', () => {
 
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
             expect(whoamiSpy.callCount).toEqual(0);
@@ -118,7 +111,7 @@ describe('CryptoClient', () => {
 
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -138,7 +131,7 @@ describe('CryptoClient', () => {
             const { client } = createTestClient(null, userId, cryptoStoreType);
 
             await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
-            // await client.crypto.prepare([]); // deliberately commented
+            // await client.crypto.prepare(); // deliberately commented
 
             try {
                 await client.crypto.isRoomEncrypted("!new:example.org");
@@ -159,7 +152,7 @@ describe('CryptoClient', () => {
 
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -176,7 +169,7 @@ describe('CryptoClient', () => {
 
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -193,7 +186,7 @@ describe('CryptoClient', () => {
 
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -210,7 +203,7 @@ describe('CryptoClient', () => {
 
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -248,7 +241,7 @@ describe('CryptoClient', () => {
         it('should sign the object while retaining signatures without mutation', async () => {
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -305,7 +298,7 @@ describe('CryptoClient', () => {
         it('should fail in unencrypted rooms', async () => {
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -381,7 +374,7 @@ describe('CryptoClient', () => {
         it('should encrypt media', async () => {
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -467,7 +460,7 @@ describe('CryptoClient', () => {
         it('should be symmetrical', async () => {
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -492,7 +485,7 @@ describe('CryptoClient', () => {
         it('should decrypt', async () => {
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
 
@@ -522,7 +515,7 @@ describe('CryptoClient', () => {
             await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
             bindNullEngine(http);
             await Promise.all([
-                client.crypto.prepare([]),
+                client.crypto.prepare(),
                 http.flushAllExpected(),
             ]);
         }));

--- a/test/encryption/KeyBackupTest.ts
+++ b/test/encryption/KeyBackupTest.ts
@@ -21,7 +21,7 @@ describe('KeyBackups', () => {
     const prepareCrypto = async () => {
         bindNullEngine(http);
         await Promise.all([
-            client.crypto.prepare([]),
+            client.crypto.prepare(),
             http.flushAllExpected(),
         ]);
     };

--- a/test/encryption/RoomTrackerTest.ts
+++ b/test/encryption/RoomTrackerTest.ts
@@ -44,7 +44,7 @@ describe('RoomTracker', () => {
         await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
         bindNullEngine(http);
         await Promise.all([
-            client.crypto.prepare([]),
+            client.crypto.prepare(),
             http.flushAllExpected(),
         ]);
         (client.crypto as any).engine.addTrackedUsers = () => Promise.resolve();
@@ -72,7 +72,7 @@ describe('RoomTracker', () => {
         await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
         bindNullEngine(http);
         await Promise.all([
-            client.crypto.prepare([]),
+            client.crypto.prepare(),
             http.flushAllExpected(),
         ]);
 
@@ -102,24 +102,6 @@ describe('RoomTracker', () => {
         await new Promise<void>(resolve => setTimeout(() => resolve(), 250));
         expect(queueSpy.callCount).toEqual(1);
     }));
-
-    describe('prepare', () => {
-        it('should queue updates for rooms', async () => {
-            const roomIds = ["!a:example.org", "!b:example.org"];
-
-            const { client } = createTestClient();
-
-            const queueSpy = simple.stub().callFn((rid: string) => {
-                expect(rid).toEqual(roomIds[queueSpy.callCount - 1]);
-                return Promise.resolve();
-            });
-
-            const tracker = new RoomTracker(client);
-            tracker.queueRoomCheck = queueSpy;
-            await tracker.prepare(roomIds);
-            expect(queueSpy.callCount).toEqual(2);
-        });
-    });
 
     describe('queueRoomCheck', () => {
         it('should store unknown rooms', () => testCryptoStores(async (cryptoStoreType) => {


### PR DESCRIPTION
We need this for specific situations where a bot is joined to a LOT of rooms, but the encrypted rooms are in the minority.

This should:
 - Cache rooms that explicitly do not have a encryption state event.
 - Recheck every time we see an encryption state event.

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
