### PR TITLE
Batch tracked users setup

### DIFF
--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -92,7 +92,11 @@ export class RustEngine {
         return this.addTrackedUsersPromise = this.lock.acquire(SYNC_LOCK_NAME, async () => {
             // Immediately clear this promise so that a new promise is queued up.
             this.addTrackedUsersPromise = undefined;
-            const uids = [...this.trackedUsersToAdd].map(u => new UserId(u));
+            const uids = Array<UserId>(this.trackedUsersToAdd.size);
+            let idx = 0;
+            for (const u of this.trackedUsersToAdd.values()) {
+                uids[idx++] = new UserId(u);
+            }
             // Clear the existing pool
             this.trackedUsersToAdd.clear();
             await this.machine.updateTrackedUsers(uids);

--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -92,7 +92,7 @@ export class RustEngine {
         return this.addTrackedUsersPromise = this.lock.acquire(SYNC_LOCK_NAME, async () => {
             // Immediately clear this promise so that a new promise is queued up.
             this.addTrackedUsersPromise = undefined;
-            const uids = Array<UserId>(this.trackedUsersToAdd.size);
+            const uids = new Array<UserId>(this.trackedUsersToAdd.size);
             let idx = 0;
             for (const u of this.trackedUsersToAdd.values()) {
                 uids[idx++] = new UserId(u);


### PR DESCRIPTION
The intention here is to handle things when thousands of requests are made to add tracked users and the async lock gets dogpiled. Async lock has a (sensible) limit of 1000 acquires before it gives up, so I think we should just queue up requests in a big batch and handle them like so.

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
