### PR TITLE
Fix PowerLevel calculation in MatrixClient helper functions

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1039,7 +1039,7 @@ export class MatrixClient extends EventEmitter {
      */
     public async getRoomStateEventBody(roomId: string, type: string, stateKey: string): Promise<APIRoomStateEvent> {
         // https://spec.matrix.org/unstable/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
-        if (this.doesServerSupportVersion("v1.16")) {
+        if (await this.doesServerSupportVersion("v1.16")) {
             const path = `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state/${encodeURIComponent(type)}/${encodeURIComponent(stateKey)}`;
             const data = await this.doRequest("GET", path, { format: "event" });
             return this.processEvent(data);
@@ -1544,7 +1544,7 @@ export class MatrixClient extends EventEmitter {
             return existing;
         }
         // We have to use getRoomState since no API exists to pull the full event, and we need the `sender` propety.
-        const createEventRaw = (await this.getRoomState(roomId)).find(ev => ev.type === 'm.room.create' && ev.state_key === '');
+        const createEventRaw = this.getRoomStateEventBody(roomId, "m.room.create", "");
         const createEvent = new CreateEvent(createEventRaw);
         this.createEventCache.set(roomId, createEvent);
         return createEvent;

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1560,7 +1560,7 @@ export class MatrixClient extends EventEmitter {
      */
     @timedMatrixClientFunctionCall()
     public async userHasPowerLevelFor(userId: string, roomId: string, eventType: string, isState: boolean): Promise<boolean> {
-        const pls = PLManager.createFromCreateAndPowerLevel(
+        const pls = new PLManager(
             await this.getCreateEventForRoom(roomId),
             await this.getRoomStateEventContent(roomId, "m.room.power_levels"),
         );
@@ -1582,7 +1582,7 @@ export class MatrixClient extends EventEmitter {
      */
     @timedMatrixClientFunctionCall()
     public async userHasPowerLevelForAction(userId: string, roomId: string, action: PowerLevelAction): Promise<boolean> {
-        const pls = PLManager.createFromCreateAndPowerLevel(
+        const pls = new PLManager(
             await this.getCreateEventForRoom(roomId),
             await this.getRoomStateEventContent(roomId, "m.room.power_levels"),
         );
@@ -1621,7 +1621,7 @@ export class MatrixClient extends EventEmitter {
         const canChangePower = await this.userHasPowerLevelFor(myUserId, roomId, "m.room.power_levels", true);
         if (!canChangePower) return { canModify: false, maximumPossibleLevel: 0 };
 
-        const pls = PLManager.createFromCreateAndPowerLevel(
+        const pls = new PLManager(
             await this.getCreateEventForRoom(roomId),
             await this.getRoomStateEventContent(roomId, "m.room.power_levels"),
         );

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1606,11 +1606,11 @@ export class MatrixClient extends EventEmitter {
         let requiredPower = defaultForActions[action];
 
         const investigate = pls.currentPL;
-        let investigated: number | undefined;
+        let investigated: number | Record<string, number>;
         // Trivial object traversal with '.' seperator.
         action.split('.').forEach(k => (investigated = investigate?.[k]));
         // Only accept numbers that are valid power levels.
-        if (Number.isFinite(investigated)) requiredPower = investigated;
+        if (typeof investigated === "number" && Number.isFinite(investigated)) requiredPower = investigated;
 
         return pls.getUserPowerLevel(userId) >= requiredPower;
     }

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1605,7 +1605,7 @@ export class MatrixClient extends EventEmitter {
 
         let requiredPower = defaultForActions[action];
 
-        let investigate = pls.currentPL;
+        const investigate = pls.currentPL;
         let investigated: number | undefined;
         // Trivial object traversal with '.' seperator.
         action.split('.').forEach(k => (investigated = investigate?.[k]));

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1610,7 +1610,9 @@ export class MatrixClient extends EventEmitter {
         // Trivial object traversal with '.' seperator.
         action.split('.').forEach(k => (investigated = investigate?.[k]));
         // Only accept numbers that are valid power levels.
-        if (typeof investigated === "number" && Number.isFinite(investigated)) requiredPower = investigated;
+        if (typeof investigated === "number" && Number.isFinite(investigated)) {
+            requiredPower = investigated;
+        }
 
         return pls.getUserPowerLevel(userId) >= requiredPower;
     }

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -50,6 +50,7 @@ import { MatrixContentScannerClient } from "./MatrixContentScannerClient";
 import { MatrixCapabilities } from "./models/Capabilities";
 import { PLManager, PowerLevelAction, PowerLevelBounds } from "./models/PowerLevels";
 import { CreateEvent, CreateEventContent } from "./models/events/CreateEvent";
+import { Json } from "./helpers/Types";
 
 const SYNC_BACKOFF_MIN_MS = 5000;
 const SYNC_BACKOFF_MAX_MS = 15000;
@@ -1029,8 +1030,8 @@ export class MatrixClient extends EventEmitter {
             + encodeURIComponent(roomId) + "/state/"
             + encodeURIComponent(type) + "/"
             + encodeURIComponent(stateKey);
-        const data = await this.doRequest("GET", path, { format: "content" });
-        return this.processEvent(data);
+        const data = await this.doRequest("GET", path);
+        return data;
     }
 
     /**
@@ -1609,7 +1610,7 @@ export class MatrixClient extends EventEmitter {
         // Trivial object traversal with '.' seperator.
         action.split('.').forEach(k => (investigate = investigate?.[k]));
         // Only accept numbers that are valid power levels.
-        if (Number.isFinite(investigated)) {
+        if (typeof investigate === "number" && Number.isFinite(investigate)) {
             requiredPower = investigate;
         }
 

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1003,7 +1003,7 @@ export class MatrixClient extends EventEmitter {
      * @param stateKey the state key
      * @returns resolves to the state event
      * @throws If the event could not be found or you do not have access to the room.
-     * @deprecated Use `getRoomStateEventContent` instead.
+     * @deprecated Use {@link getRoomStateEventContent} instead.
      */
     @timedMatrixClientFunctionCall()
     public getRoomStateEvent(roomId, type, stateKey): Promise<any> {
@@ -1543,8 +1543,7 @@ export class MatrixClient extends EventEmitter {
         if (existing) {
             return existing;
         }
-        // We have to use getRoomState since no API exists to pull the full event, and we need the `sender` propety.
-        const createEventRaw = this.getRoomStateEventBody(roomId, "m.room.create", "");
+        const createEventRaw = await this.getRoomStateEventBody(roomId, "m.room.create", "");
         const createEvent = new CreateEvent(createEventRaw);
         this.createEventCache.set(roomId, createEvent);
         return createEvent;

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1028,7 +1028,7 @@ export class MatrixClient extends EventEmitter {
         const path = "/_matrix/client/v3/rooms/"
             + encodeURIComponent(roomId) + "/state/"
             + encodeURIComponent(type) + "/"
-            + encodeURIComponent(stateKey ? stateKey : '');
+            + encodeURIComponent(stateKey);
         const data = await this.doRequest("GET", path, { format: "content" });
         return this.processEvent(data);
     }
@@ -1048,7 +1048,7 @@ export class MatrixClient extends EventEmitter {
             const path = "/_matrix/client/v3/rooms/"
                 + encodeURIComponent(roomId) + "/state/"
                 + encodeURIComponent(type) + "/"
-                + encodeURIComponent(stateKey ? stateKey : '');
+                + encodeURIComponent(stateKey);
             const data = await this.doRequest("GET", path, { format: "event" });
             return this.processEvent(data);
         }
@@ -1605,13 +1605,12 @@ export class MatrixClient extends EventEmitter {
 
         let requiredPower = defaultForActions[action];
 
-        const investigate = pls.currentPL;
-        let investigated: number | Record<string, number>;
+        let investigate = pls.currentPL as Json;
         // Trivial object traversal with '.' seperator.
-        action.split('.').forEach(k => (investigated = investigate?.[k]));
+        action.split('.').forEach(k => (investigate = investigate?.[k]));
         // Only accept numbers that are valid power levels.
-        if (typeof investigated === "number" && Number.isFinite(investigated)) {
-            requiredPower = investigated;
+        if (Number.isFinite(investigated)) {
+            requiredPower = investigate;
         }
 
         return pls.getUserPowerLevel(userId) >= requiredPower;

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1030,7 +1030,7 @@ export class MatrixClient extends EventEmitter {
             + encodeURIComponent(type) + "/"
             + encodeURIComponent(stateKey ? stateKey : '');
         const data = await this.doRequest("GET", path, { format: "content" });
-        return data;
+        return this.processEvent(data);
     }
 
     /**

--- a/src/e2ee/RoomTracker.ts
+++ b/src/e2ee/RoomTracker.ts
@@ -49,7 +49,7 @@ export class RoomTracker {
 
         let encEvent: Partial<EncryptionEventContent>;
         try {
-            encEvent = await this.client.getRoomStateEvent(roomId, "m.room.encryption", "");
+            encEvent = await this.client.getRoomStateEventContent(roomId, "m.room.encryption", "");
             encEvent.algorithm = encEvent.algorithm ?? 'UNKNOWN';
         } catch (e) {
             if (e instanceof MatrixError && e.errcode === "M_NOT_FOUND") {
@@ -62,8 +62,8 @@ export class RoomTracker {
         // Pick out the history visibility setting too
         let historyVisibility: string;
         try {
-            const ev = await this.client.getRoomStateEvent(roomId, "m.room.history_visibility", "");
-            historyVisibility = ev.history_visibility;
+            const ev = await this.client.getRoomStateEventContent(roomId, "m.room.history_visibility", "");
+            historyVisibility = ev.history_visibility as string;
         } catch (e) {
             // ignore - we'll just treat history visibility as normal
         }

--- a/src/helpers/MentionPill.ts
+++ b/src/helpers/MentionPill.ts
@@ -40,7 +40,7 @@ export class MentionPill {
                 let profile = null;
 
                 if (inRoomId) {
-                    profile = await client.getRoomStateEvent(inRoomId, "m.room.member", userId);
+                    profile = await client.getRoomStateEventContent(inRoomId, "m.room.member", userId);
                 }
                 if (!profile) {
                     profile = await client.getUserProfile(userId);
@@ -70,9 +70,9 @@ export class MentionPill {
         try {
             if (client) {
                 const roomId = await client.resolveRoom(roomIdOrAlias);
-                const canonicalAlias = await client.getRoomStateEvent(roomId, "m.room.canonical_alias", "");
+                const canonicalAlias = await client.getRoomStateEventContent(roomId, "m.room.canonical_alias", "");
                 if (canonicalAlias?.alias) {
-                    displayProp = canonicalAlias.alias;
+                    displayProp = canonicalAlias.alias as string;
                     permalink = Permalinks.forRoom(displayProp);
                 }
             }

--- a/src/helpers/ProfileCache.ts
+++ b/src/helpers/ProfileCache.ts
@@ -88,7 +88,7 @@ export class ProfileCache {
     private async getUserProfileWith(userId: string, roomId: string, client: MatrixClient): Promise<MatrixProfile> {
         try {
             if (roomId) {
-                const membership = await client.getRoomStateEvent(roomId, "m.room.member", userId);
+                const membership = await client.getRoomStateEventContent(roomId, "m.room.member", userId);
                 return new MatrixProfile(userId, membership);
             } else {
                 const profile = await client.getUserProfile(userId);

--- a/src/identity/IdentityClient.ts
+++ b/src/identity/IdentityClient.ts
@@ -157,7 +157,7 @@ export class IdentityClient {
 
         const tryFetch = async (eventType: string, stateKey: string): Promise<any> => {
             try {
-                return await this.matrixClient.getRoomStateEvent(roomId, eventType, stateKey);
+                return await this.matrixClient.getRoomStateEventContent(roomId, eventType, stateKey);
             } catch (e) {
                 return null;
             }

--- a/src/models/PowerLevels.ts
+++ b/src/models/PowerLevels.ts
@@ -1,4 +1,5 @@
 import {
+    CreateEvent,
     type MatrixClient,
     type PowerLevelsEventContent,
     UserID,
@@ -86,7 +87,7 @@ export class PLManager {
         return this.powerLevels?.users_default ?? 0;
     }
 
-    private constructor(
+    constructor(
         private readonly createEvent: {
             sender: string;
             content: CreateEventContentHydra | CreateEventContentLegacy;

--- a/src/models/PowerLevels.ts
+++ b/src/models/PowerLevels.ts
@@ -1,5 +1,4 @@
 import {
-    CreateEvent,
     type MatrixClient,
     type PowerLevelsEventContent,
     UserID,

--- a/src/models/events/CreateEvent.ts
+++ b/src/models/events/CreateEvent.ts
@@ -63,7 +63,7 @@ export class CreateEvent extends StateEvent<CreateEventContent> {
      * The user ID who created the room.
      */
     public get creator(): string {
-        return this.content.creator || this.sender;
+        return this.sender;
     }
 
     /**

--- a/src/models/events/RoomEvent.ts
+++ b/src/models/events/RoomEvent.ts
@@ -85,19 +85,17 @@ export class StateEvent<T extends (Object | unknown) = unknown> extends RoomEven
  * Raw event as it appears on the CS API
  */
 export interface APIRoomEvent {
-    content: Record<string, unknown>;
+    content: Record<string, Json>;
     event_id: string;
     origin_server_ts: number;
     room_id: string;
     sender: string;
     state_key?: string;
     type: string;
-    unsigned: Record<string, unknown>;
+    unsigned: Record<string, Json>;
 }
 
 /**
  * Raw state event as it appears on the CS API
  */
-export interface APIRoomStateEvent extends Omit<APIRoomEvent, "state_key"> {
-    state_key: string;
-}
+export type APIRoomStateEvent = APIRoomEvent & Required<Pick<APIRoomEvent, "state_key">>;

--- a/src/models/events/RoomEvent.ts
+++ b/src/models/events/RoomEvent.ts
@@ -85,14 +85,14 @@ export class StateEvent<T extends (Object | unknown) = unknown> extends RoomEven
  * Raw event as it appears on the CS API
  */
 export interface APIRoomEvent {
-    content: Record<string, Json>;
+    content: Record<string, unknown>;
     event_id: string;
     origin_server_ts: number;
     room_id: string;
     sender: string;
     state_key?: string;
     type: string;
-    unsigned: Record<string, Json>;
+    unsigned: Record<string, unknown>;
 }
 
 /**

--- a/src/models/events/RoomEvent.ts
+++ b/src/models/events/RoomEvent.ts
@@ -81,3 +81,23 @@ export class StateEvent<T extends (Object | unknown) = unknown> extends RoomEven
     }
 }
 
+/**
+ * Raw event as it appears on the CS API
+ */
+export interface APIRoomEvent {
+    content: Record<string, unknown>;
+    event_id: string;
+    origin_server_ts: number;
+    room_id: string;
+    sender: string;
+    state_key?: string;
+    type: string;
+    unsigned: Record<string, unknown>;
+}
+
+/**
+ * Raw state event as it appears on the CS API
+ */
+export interface APIRoomStateEvent extends Omit<APIRoomEvent, "state_key"> {
+    state_key: string;
+}

--- a/test/IdentityClientTest.ts
+++ b/test/IdentityClientTest.ts
@@ -611,7 +611,7 @@ describe('IdentityClient', () => {
             };
 
             const stateStub = () => Promise.resolve(null);
-            client.matrixClient.getRoomStateEvent = stateStub;
+            client.matrixClient.getRoomStateEventContent = stateStub;
             client.matrixClient.getUserProfile = stateStub;
 
             http.when("POST", "/_matrix/identity/v2/store-invite").respond(200, (path, content) => {
@@ -677,7 +677,7 @@ describe('IdentityClient', () => {
                         throw new Error("Unknown event type");
                 }
             };
-            client.matrixClient.getRoomStateEvent = stateStub;
+            client.matrixClient.getRoomStateEventContent = stateStub;
             const profileSpy = simple.mock(client.matrixClient, "getUserProfile").callFn(() => {
                 return Promise.resolve({ displayname: senderDisplayName, avatar_url: senderAvatarUrl });
             });
@@ -752,7 +752,7 @@ describe('IdentityClient', () => {
                         throw new Error("Unknown event type");
                 }
             };
-            client.matrixClient.getRoomStateEvent = stateStub;
+            client.matrixClient.getRoomStateEventContent = stateStub;
             const profileSpy = simple.mock(client.matrixClient, "getUserProfile").callFn(() => {
                 return Promise.resolve({ displayname: senderDisplayName, avatar_url: senderAvatarUrl });
             });

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -2642,7 +2642,7 @@ describe('MatrixClient', () => {
         const event = { roomId, type: eventType, content: { name: "My name" }, state_key: stateKey };
         it('should call the right endpoint with an empty state key', async () => {
             const { client, http, hsUrl } = createTestClient(undefined, undefined, undefined, { precacheVersions: false });
-            http.when("GET", "/_matrix/client/versions").respond(200, { versions: ["v1.16"]} satisfies ServerVersions);
+            http.when("GET", "/_matrix/client/versions").respond(200, { versions: ["v1.16"] } satisfies ServerVersions);
             // noinspection TypeScriptValidateJSTypes
             http.when("GET", "/_matrix/client/v3/rooms").respond(200, (path) => {
                 expect(path).toEqual(`${hsUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state/${encodeURIComponent(eventType)}/`);
@@ -2655,7 +2655,7 @@ describe('MatrixClient', () => {
 
         it('should call the right endpoint with a state key', async () => {
             const { client, http, hsUrl } = createTestClient(undefined, undefined, undefined, { precacheVersions: false });
-            http.when("GET", "/_matrix/client/versions").respond(200, { versions: ["v1.16"]} satisfies ServerVersions);
+            http.when("GET", "/_matrix/client/versions").respond(200, { versions: ["v1.16"] } satisfies ServerVersions);
 
             // noinspection TypeScriptValidateJSTypes
             http.when("GET", "/_matrix/client/v3/rooms").respond(200, (path) => {
@@ -2669,7 +2669,7 @@ describe('MatrixClient', () => {
 
         it('should process events with no state key', async () => {
             const { client, http, hsUrl } = createTestClient(undefined, undefined, undefined, { precacheVersions: false });
-            http.when("GET", "/_matrix/client/versions").respond(200, { versions: ["v1.16"]} satisfies ServerVersions);
+            http.when("GET", "/_matrix/client/versions").respond(200, { versions: ["v1.16"] } satisfies ServerVersions);
 
             const processor = <IPreprocessor>{
                 processEvent: (ev, procClient, kind?) => {
@@ -2694,7 +2694,7 @@ describe('MatrixClient', () => {
 
         it('should call the fallback endpoint with a state key', async () => {
             const { client, http } = createTestClient(undefined, undefined, undefined, { precacheVersions: false });
-            http.when("GET", "/_matrix/client/versions").respond(200, { versions: []} satisfies ServerVersions);
+            http.when("GET", "/_matrix/client/versions").respond(200, { versions: [] } satisfies ServerVersions);
 
             // noinspection TypeScriptValidateJSTypes
             http.when("GET", `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state`).respond(200, () => {
@@ -2705,7 +2705,6 @@ describe('MatrixClient', () => {
             expect(result).toMatchObject(event);
         });
     });
-
 
     describe('getEventContext', () => {
         it('should use the right endpoint', async () => {

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -2617,7 +2617,7 @@ describe('MatrixClient', () => {
                 return event;
             });
 
-            const [result] = await Promise.all([client.getRoomStateEvent(roomId, eventType, ""), http.flushAllExpected()]);
+            const [result] = await Promise.all([client.getRoomStateEventContent(roomId, eventType, ""), http.flushAllExpected()]);
             expect(result).toMatchObject(event);
         });
 
@@ -2635,7 +2635,7 @@ describe('MatrixClient', () => {
                 return event;
             });
 
-            const [result] = await Promise.all([client.getRoomStateEvent(roomId, eventType, stateKey), http.flushAllExpected()]);
+            const [result] = await Promise.all([client.getRoomStateEventContent(roomId, eventType, stateKey), http.flushAllExpected()]);
             expect(result).toMatchObject(event);
         });
 
@@ -2661,7 +2661,7 @@ describe('MatrixClient', () => {
                 return event;
             });
 
-            const [result] = await Promise.all([client.getRoomStateEvent(roomId, eventType, ""), http.flushAllExpected()]);
+            const [result] = await Promise.all([client.getRoomStateEventContent(roomId, eventType, ""), http.flushAllExpected()]);
             expect(result).toMatchObject(event);
             expect(result["processed"]).toBeTruthy();
         });
@@ -2689,7 +2689,7 @@ describe('MatrixClient', () => {
                 return event;
             });
 
-            const [result] = await Promise.all([client.getRoomStateEvent(roomId, eventType, stateKey), http.flushAllExpected()]);
+            const [result] = await Promise.all([client.getRoomStateEventContent(roomId, eventType, stateKey), http.flushAllExpected()]);
             expect(result).toMatchObject(event);
             expect(result["processed"]).toBeTruthy();
         });

--- a/test/encryption/CryptoClientTest.ts
+++ b/test/encryption/CryptoClientTest.ts
@@ -163,7 +163,7 @@ describe('CryptoClient', () => {
             const { client, http } = createTestClient(null, userId, cryptoStoreType);
 
             await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
-            client.getRoomStateEvent = () => Promise.reject(new Error("not used"));
+            client.getRoomStateEventContent = () => Promise.reject(new Error("not used"));
 
             bindNullEngine(http);
             await Promise.all([
@@ -180,7 +180,7 @@ describe('CryptoClient', () => {
             const { client, http } = createTestClient(null, userId, cryptoStoreType);
 
             await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
-            client.getRoomStateEvent = () => Promise.reject(new Error("implied 404"));
+            client.getRoomStateEventContent = () => Promise.reject(new Error("implied 404"));
 
             bindNullEngine(http);
             await Promise.all([
@@ -197,7 +197,7 @@ describe('CryptoClient', () => {
             const { client, http } = createTestClient(null, userId, cryptoStoreType);
 
             await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
-            client.getRoomStateEvent = () => Promise.resolve({});
+            client.getRoomStateEventContent = () => Promise.resolve({});
 
             bindNullEngine(http);
             await Promise.all([
@@ -214,7 +214,7 @@ describe('CryptoClient', () => {
             const { client, http } = createTestClient(null, userId, cryptoStoreType);
 
             await client.cryptoStore.setDeviceId(TEST_DEVICE_ID);
-            client.getRoomStateEvent = () => Promise.resolve({ algorithm: RoomEncryptionAlgorithm.MegolmV1AesSha2 });
+            client.getRoomStateEventContent = () => Promise.resolve({ algorithm: RoomEncryptionAlgorithm.MegolmV1AesSha2 });
 
             bindNullEngine(http);
             await Promise.all([

--- a/test/encryption/RoomTrackerTest.ts
+++ b/test/encryption/RoomTrackerTest.ts
@@ -31,7 +31,7 @@ function prepareQueueSpies(
 
     client.cryptoStore.getRoom = readSpy;
     client.cryptoStore.storeRoom = storeSpy;
-    client.getRoomStateEvent = stateSpy;
+    client.getRoomStateEventContent = stateSpy;
 
     return [readSpy, stateSpy, storeSpy];
 }
@@ -141,7 +141,7 @@ describe('RoomTracker', () => {
             const { client } = createTestClient(null, "@user:example.org", cryptoStoreType);
 
             const [readSpy, stateSpy, storeSpy] = prepareQueueSpies(client, roomId, content);
-            client.getRoomStateEvent = async (rid: string, et: string, sk: string) => {
+            client.getRoomStateEventContent = async (rid: string, et: string, sk: string) => {
                 await stateSpy(rid, et, sk);
                 throw new Error("Simulated 404");
             };

--- a/test/helpers/MentionPillTest.ts
+++ b/test/helpers/MentionPillTest.ts
@@ -41,7 +41,7 @@ describe('MentionPill', () => {
                 expect(uid).toEqual(userId);
                 return { displayname: displayName };
             });
-            const stateSpy = simple.mock(client, "getRoomStateEvent").callFn((rid, eventType, stateKey) => {
+            const stateSpy = simple.mock(client, "getRoomStateEventContent").callFn((rid, eventType, stateKey) => {
                 throw new Error("Unexpected call");
             });
 
@@ -65,7 +65,7 @@ describe('MentionPill', () => {
             const profileSpy = simple.mock(client, "getUserProfile").callFn((uid) => {
                 throw new Error("Unexpected call");
             });
-            const stateSpy = simple.mock(client, "getRoomStateEvent").callFn((rid, eventType, stateKey) => {
+            const stateSpy = simple.mock(client, "getRoomStateEventContent").callFn((rid, eventType, stateKey) => {
                 expect(rid).toBe(roomId);
                 expect(eventType).toBe("m.room.member");
                 expect(stateKey).toBe(userId);
@@ -90,7 +90,7 @@ describe('MentionPill', () => {
             const profileSpy = simple.mock(client, "getUserProfile").callFn((uid) => {
                 throw new Error("Simulated failure 1");
             });
-            const stateSpy = simple.mock(client, "getRoomStateEvent").callFn((rid, eventType, stateKey) => {
+            const stateSpy = simple.mock(client, "getRoomStateEventContent").callFn((rid, eventType, stateKey) => {
                 throw new Error("Simulated failure 2");
             });
 
@@ -113,7 +113,7 @@ describe('MentionPill', () => {
             const profileSpy = simple.mock(client, "getUserProfile").callFn((uid) => {
                 throw new Error("Simulated failure 1");
             });
-            const stateSpy = simple.mock(client, "getRoomStateEvent").callFn((rid, eventType, stateKey) => {
+            const stateSpy = simple.mock(client, "getRoomStateEventContent").callFn((rid, eventType, stateKey) => {
                 throw new Error("Simulated failure 2");
             });
 
@@ -162,7 +162,7 @@ describe('MentionPill', () => {
                 expect(ref).toBe(roomAlias);
                 return roomId;
             });
-            const getStateSpy = simple.mock(client, "getRoomStateEvent").callFn(async (sRoomId, type, stateKey) => {
+            const getStateSpy = simple.mock(client, "getRoomStateEventContent").callFn(async (sRoomId, type, stateKey) => {
                 expect(sRoomId).toBe(roomId);
                 expect(type).toBe("m.room.canonical_alias");
                 expect(stateKey).toBe("");

--- a/test/helpers/ProfileCacheTest.ts
+++ b/test/helpers/ProfileCacheTest.ts
@@ -12,7 +12,7 @@ describe('ProfileCache', () => {
 
         const { client } = createTestClient();
 
-        const getStateEventSpy = simple.mock(client, "getRoomStateEvent").callFn((rid, type, stateKey) => {
+        const getStateEventSpy = simple.mock(client, "getRoomStateEventContent").callFn((rid, type, stateKey) => {
             expect(rid).toBe(roomId);
             expect(type).toBe("m.room.member");
             expect(stateKey).toBe(userId);
@@ -68,7 +68,7 @@ describe('ProfileCache', () => {
         const { client: client1 } = createTestClient();
         const { client: client2 } = createTestClient();
 
-        const getStateEventSpy1 = simple.mock(client1, "getRoomStateEvent").callFn((rid, type, stateKey) => {
+        const getStateEventSpy1 = simple.mock(client1, "getRoomStateEventContent").callFn((rid, type, stateKey) => {
             expect(rid).toBe(roomId);
             expect(type).toBe("m.room.member");
             expect(stateKey).toBe(userId);
@@ -79,7 +79,7 @@ describe('ProfileCache', () => {
             return Promise.resolve(generalProfile);
         });
 
-        const getStateEventSpy2 = simple.mock(client2, "getRoomStateEvent").callFn((rid, type, stateKey) => {
+        const getStateEventSpy2 = simple.mock(client2, "getRoomStateEventContent").callFn((rid, type, stateKey) => {
             expect(rid).toBe(roomId);
             expect(type).toBe("m.room.member");
             expect(stateKey).toBe(userId);
@@ -180,7 +180,7 @@ describe('ProfileCache', () => {
             },
         });
 
-        const getStateEventSpy1 = simple.mock(client1, "getRoomStateEvent").callFn((rid, type, stateKey) => {
+        const getStateEventSpy1 = simple.mock(client1, "getRoomStateEventContent").callFn((rid, type, stateKey) => {
             expect(rid).toBe(roomId);
             expect(type).toBe("m.room.member");
             expect(stateKey).toBe(userId);
@@ -191,7 +191,7 @@ describe('ProfileCache', () => {
             return Promise.resolve(generalProfile);
         });
 
-        const getStateEventSpy2 = simple.mock(client2, "getRoomStateEvent").callFn((rid, type, stateKey) => {
+        const getStateEventSpy2 = simple.mock(client2, "getRoomStateEventContent").callFn((rid, type, stateKey) => {
             expect(rid).toBe(roomId);
             expect(type).toBe("m.room.member");
             expect(stateKey).toBe(userId);

--- a/test/models/PowerLevelsTest.ts
+++ b/test/models/PowerLevelsTest.ts
@@ -137,12 +137,20 @@ describe("PLManager", function() {
             state_key: "",
             sender: PrimaryCreator,
             content: createEventContent,
+            event_id: "$create",
+            origin_server_ts: 1,
+            room_id: "!unused",
+            unsigned: {},
         };
         const powerLevelEvent = plContent && {
             type: "m.room.power_levels",
             state_key: "",
             sender: PrimaryCreator,
-            content: plContent,
+            content: plContent as Record<string, unknown>,
+            event_id: "$create",
+            origin_server_ts: 1,
+            room_id: "!unused",
+            unsigned: {},
         };
 
         describe(`with room version ${createEvent.content.room_version} and extra creators=${createEvent.content.additional_creators}`, function() {

--- a/test/models/PowerLevelsTest.ts
+++ b/test/models/PowerLevelsTest.ts
@@ -146,7 +146,7 @@ describe("PLManager", function() {
             type: "m.room.power_levels",
             state_key: "",
             sender: PrimaryCreator,
-            content: plContent,
+            content: plContent as Record<string, unknown>,
             event_id: "$create",
             origin_server_ts: 1,
             room_id: "!unused",

--- a/test/models/PowerLevelsTest.ts
+++ b/test/models/PowerLevelsTest.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src";
 
 const PrimaryCreator = "@alice:bar";
-const ExtraCreators = Object.freeze(["@bob:bar", "@charlie:bar"]);
+const ExtraCreators = ["@bob:bar", "@charlie:bar"];
 
 type TestCandidate = [
     {
@@ -14,7 +14,7 @@ type TestCandidate = [
         canAdjustPL: boolean;
         creatorPL: number;
     },
-    { room_version?: string, additional_creators?: readonly string[] },
+    { room_version?: string, additional_creators?: string[] },
     PowerLevelsEventContent | undefined,
 ];
 
@@ -146,7 +146,7 @@ describe("PLManager", function() {
             type: "m.room.power_levels",
             state_key: "",
             sender: PrimaryCreator,
-            content: plContent as Record<string, unknown>,
+            content: plContent,
             event_id: "$create",
             origin_server_ts: 1,
             room_id: "!unused",

--- a/test/models/SpacesTest.ts
+++ b/test/models/SpacesTest.ts
@@ -1,6 +1,6 @@
 import * as simple from "simple-mock";
 
-import { Space } from "../../src";
+import { APIRoomStateEvent, Space } from "../../src";
 import { createTestClient } from "../TestUtils";
 
 describe('Space', () => {
@@ -215,12 +215,13 @@ describe('Space', () => {
 
             const parentRoomId = "!parent:example.org";
             const expectedRoomIds = ["!room2:example.org", "!room4:example.org"];
-            const stateEvents = [
-                { type: "m.room.create", content: { type: 'm.space' }, state_key: "" },
-                { type: "m.space.child", content: { suggested: true, via: [via] }, state_key: "!room1:example.org" },
-                { type: "m.space.child", content: { suggested: false, via: [via] }, state_key: expectedRoomIds[0] },
-                { type: "m.space.child", content: { suggested: true, via: [via2] }, state_key: "!room3:example.org" },
-                { type: "m.space.child", content: { suggested: false, via: [via2] }, state_key: expectedRoomIds[1] },
+            const extra = { event_id: "$foo", room_id: "!room", origin_server_ts: 1, sender: "@sender", unsigned: {} };
+            const stateEvents: APIRoomStateEvent[] = [
+                { type: "m.room.create", content: { type: 'm.space' }, state_key: "", ...extra },
+                { type: "m.space.child", content: { suggested: true, via: [via] }, state_key: "!room1:example.org", ...extra },
+                { type: "m.space.child", content: { suggested: false, via: [via] }, state_key: expectedRoomIds[0], ...extra },
+                { type: "m.space.child", content: { suggested: true, via: [via2] }, state_key: "!room3:example.org", ...extra },
+                { type: "m.space.child", content: { suggested: false, via: [via2] }, state_key: expectedRoomIds[1], ...extra },
             ];
             client.getRoomState = async (roomId) => {
                 expect(roomId).toBe(parentRoomId);

--- a/test/models/events/CreateEventTest.ts
+++ b/test/models/events/CreateEventTest.ts
@@ -4,12 +4,13 @@ import { CreateEvent } from "../../../src";
 describe("CreateEvent", () => {
     it("should return the right fields", () => {
         const ev = createMinimalEvent();
+        // Should never be used!
         ev.content['creator'] = '@bob:example.org';
         ev.content['m.federate'] = false;
         ev.content['room_version'] = '4';
         const obj = new CreateEvent(ev);
 
-        expect(obj.creator).toEqual(ev.content['creator']);
+        expect(obj.creator).toEqual(ev.sender);
         expect(obj.federated).toEqual(ev.content['m.federate']);
         expect(obj.version).toEqual(ev.content['room_version']);
     });


### PR DESCRIPTION
This is a rather large PR, as a lot of structure needed to be changed to support this. This:

- Changes the helper power level functions to take into account hydra rooms by using our `PLManager` class.
- Changes a lot of the state fetching functions to be stronger typed, and use more efficient state fetching mechanisms where possible
- Updates the codebase to use the new functions (Room upgrade chasing was skipped as the test changes were non-trivial, so skipped due to time).

This is very likely breaking for some projects, so caution should be taken before upgrading.

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
