### PR TITLE
Fix types for getRoomEvent

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -953,12 +953,12 @@ export class MatrixClient extends EventEmitter {
      * @returns {Promise<any>} resolves to the found event
      */
     @timedMatrixClientFunctionCall()
-    public async getEvent(roomId: string, eventId: string): Promise<APIRoomEvent|EncryptedRoomEvent> {
+    public async getEvent(roomId: string, eventId: string): Promise<RoomEvent<unknown>> {
         const event = await this.getRawEvent(roomId, eventId);
         if (event['type'] === 'm.room.encrypted' && await this.crypto?.isRoomEncrypted(roomId)) {
             return this.processEvent((await this.crypto.decryptRoomEvent(new EncryptedRoomEvent(event), roomId)).raw);
         }
-        return event;
+        return new RoomEvent<unknown>(event);
     }
 
     /**

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -50,7 +50,7 @@ import { MatrixContentScannerClient } from "./MatrixContentScannerClient";
 import { MatrixCapabilities } from "./models/Capabilities";
 import { PLManager, PowerLevelAction, PowerLevelBounds } from "./models/PowerLevels";
 import { CreateEvent, CreateEventContent } from "./models/events/CreateEvent";
-import { Json } from "./helpers/Types";
+import { IJsonType, Json } from "./helpers/Types";
 
 const SYNC_BACKOFF_MIN_MS = 5000;
 const SYNC_BACKOFF_MAX_MS = 15000;
@@ -953,12 +953,12 @@ export class MatrixClient extends EventEmitter {
      * @returns {Promise<any>} resolves to the found event
      */
     @timedMatrixClientFunctionCall()
-    public async getEvent(roomId: string, eventId: string): Promise<RoomEvent<unknown>> {
+    public async getEvent(roomId: string, eventId: string): Promise<RoomEvent<IJsonType>> {
         const event = await this.getRawEvent(roomId, eventId);
         if (event['type'] === 'm.room.encrypted' && await this.crypto?.isRoomEncrypted(roomId)) {
             return this.processEvent((await this.crypto.decryptRoomEvent(new EncryptedRoomEvent(event), roomId)).raw);
         }
-        return new RoomEvent<unknown>(event);
+        return new RoomEvent<IJsonType>(event);
     }
 
     /**

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -2366,7 +2366,7 @@ describe('MatrixClient', () => {
 
             const [result] = await Promise.all([client.getEvent(roomId, eventId), http.flushAllExpected()]);
             expect(result).toMatchObject(event);
-            expect(result["processed"]).toBeTruthy();
+            expect(result.raw["processed"]).toBeTruthy();
         });
 
         it('should try decryption', () => testCryptoStores(async (cryptoStoreType) => {


### PR DESCRIPTION
This actually never returns EncryptedRoomEvent, but RoomEvent on decryption. To make this easier to consume, I've changed it so that it always returns a RoomEvent instead.

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
