### PR TITLE
Revert setting a type for getRequestFn

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -16,6 +16,6 @@ export function setRequestFn(fn) {
  * @returns The request function.
  * @category Unit testing
  */
-export function getRequestFn(): typeof origRequestFn {
+export function getRequestFn() {
     return requestFn;
 }


### PR DESCRIPTION
This was causing downstream issues with projects now not able to resolve `@types/request`. For now I'm reverting this change.

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
