### PR TITLE
Split out AS APIs to subclass

### DIFF
--- a/src/AppserviceApis.ts
+++ b/src/AppserviceApis.ts
@@ -1,0 +1,29 @@
+import type { MatrixClient } from "./MatrixClient";
+
+export interface PingHomeserverResponse {
+    duration_ms: number;
+}
+
+/**
+ * APIs for use within the scope of an appservice.
+ */
+export class AppserviceApis {
+    /**
+     *
+     * @param client A client with the appservice token configured.
+     * @param appserviceId The `id` of the appservice, as per it's registration file.
+     */
+    constructor(private readonly client: MatrixClient, private readonly appserviceId?: string) { }
+
+    /**
+     * This API asks the homeserver to call the /_matrix/app/v1/ping endpoint on the application service
+     * to ensure that the homeserver can communicate with the application service.
+     * @param transactionId A unique ID that identifies the ping request.
+     */
+    public pingHomeserver(transactionId?: string): Promise<PingHomeserverResponse> {
+        if (!this.appserviceId) {
+            throw Error('No `id` given in registration information. Cannot ping homeserver');
+        }
+        return this.client.doRequest("POST", `/_matrix/client/v1/appservice/${this.appserviceId}/ping`, undefined, { transaction_id: transactionId });
+    }
+}

--- a/src/AppserviceApis.ts
+++ b/src/AppserviceApis.ts
@@ -20,7 +20,7 @@ export class AppserviceApis {
      * to ensure that the homeserver can communicate with the application service.
      * @param transactionId A unique ID that identifies the ping request.
      */
-    public pingHomeserver(transactionId?: string): Promise<PingHomeserverResponse> {
+    public pingHomeserver(transactionId: string): Promise<PingHomeserverResponse> {
         if (!this.appserviceId) {
             throw Error('No `id` given in registration information. Cannot ping homeserver');
         }

--- a/src/AppserviceApis.ts
+++ b/src/AppserviceApis.ts
@@ -11,7 +11,7 @@ export class AppserviceApis {
     /**
      *
      * @param client A client with the appservice token configured.
-     * @param appserviceId The `id` of the appservice, as per it's registration file.
+     * @param appserviceId The `id` of the appservice, as per its registration file.
      */
     constructor(private readonly client: MatrixClient, private readonly appserviceId?: string) { }
 

--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -259,7 +259,7 @@ export class Appservice extends EventEmitter {
     private pendingTransactions = new Map<string, Promise<void>>();
 
     /**
-     * Client instance that is not crypto-aware and can be used to call AS-API requests.
+     * Appservice specific APIs.
      */
     public readonly apis: AppserviceApis;
 

--- a/test/appservice/AppserviceTest.ts
+++ b/test/appservice/AppserviceTest.ts
@@ -172,7 +172,7 @@ describe('Appservice', () => {
         });
     });
 
-    describe.only('alias namespace', () => {
+    describe('alias namespace', () => {
         it('should allow multiple registered user namespaces but fail suffix functions', async () => {
             const appservice = new Appservice({
                 port: 0,
@@ -707,7 +707,7 @@ describe('Appservice', () => {
 
             const aliasA = "#_prefix_test:example.org";
             const aliasB = "#alice_prefix_:example.org";
-            const aliasC = "#alice_prefix2_:example.org";
+            const aliasC = "#_prefix2_:example.org";
 
             expect(appservice.isNamespacedAlias(aliasA)).toBeTruthy();
             expect(appservice.isNamespacedAlias(aliasB)).toBeFalsy();
@@ -1857,7 +1857,8 @@ describe('Appservice', () => {
         }
     });
 
-    it('should refresh membership information of intents when actions are performed against them', async () => {
+    // This differs from the upstream SDK as we do NOT cache the rooms the users are in.
+    it('should NOT refresh membership information of intents when actions are performed against them', async () => {
         const port = await getPort();
         const hsToken = "s3cret_token";
         const appservice = new Appservice({
@@ -1886,11 +1887,11 @@ describe('Appservice', () => {
         try {
             const intent = appservice.getIntentForSuffix("test");
             const refreshSpy = simple.stub().callFn(() => Promise.resolve([]));
-            intent.refreshJoinedRooms = refreshSpy;
+            intent.getJoinedRooms = refreshSpy;
 
             // polyfill the dummy user too
             const intent2 = appservice.getIntentForSuffix("test___WRONGUSER");
-            intent2.refreshJoinedRooms = () => Promise.resolve([]);
+            intent2.getJoinedRooms = () => Promise.resolve([]);
 
             const joinTxn = {
                 events: [
@@ -1938,8 +1939,7 @@ describe('Appservice', () => {
                 });
                 expect(res).toMatchObject({});
 
-                expect(refreshSpy.callCount).toBe(1);
-                refreshSpy.callCount = 0;
+                expect(refreshSpy.callCount).toBe(0);
             }
 
             await doCall("/transactions/1", { json: joinTxn });


### PR DESCRIPTION
Fixes #79 

This splits out AS API requests to it's own self contained class, and ensures that the token overwrite performed when encryption is enabled does not affect our ability to make regular requests to the HS.