### PR TITLE
Drop Node 22, support Node 25

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [ 22, 24 ]
+        node: [ 24, 25 ]
     name: 'Build Node ${{ matrix.node }}'
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
   build-docs:
     strategy:
       matrix:
-        node: [ 22, 24 ]
+        node: [ 24, 25 ]
     name: 'Build Docs Node ${{ matrix.node }}'
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        node: [ 22, 24 ]
+        node: [ 24, 25 ]
     name: 'Tests Node ${{ matrix.node }}'
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "keywords": [
     "matrix",
@@ -83,7 +83,7 @@
     "@types/jest": "^30.0.0",
     "@types/lowdb": "^1.0.14",
     "@types/mocha": "^10.0.3",
-    "@types/node": "22",
+    "@types/node": "24",
     "@types/request-promise": "^4.1.51",
     "@types/sanitize-html": "^2.9.3",
     "@types/simple-mock": "^0.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,12 +1118,12 @@
   dependencies:
     undici-types "~7.16.0"
 
-"@types/node@22":
-  version "22.19.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.7.tgz#434094ee1731ae76c16083008590a5835a8c39c1"
-  integrity sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==
+"@types/node@24":
+  version "24.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
+  integrity sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.16.0"
 
 "@types/node@^18.11.18":
   version "18.19.130"
@@ -6487,11 +6487,6 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici-types@~7.16.0:
   version "7.16.0"


### PR DESCRIPTION
Support current & active LTS releases of Node.

Analogous to https://github.com/element-hq/matrix-bot-sdk/pull/63.

If Node 26 is released today as scheduled, then a follow-up commit may include it in CI.