### PR TITLE
Fix Trusted Publishing workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,4 +20,4 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Publish to npmjs.com
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag latest


### PR DESCRIPTION
The --tag argument is required when making releases for versions that are prereleases according to SemVer.