### PR TITLE
fix(deps): drop htmlencode to silence Node 22 DEP0060 deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "glob-to-regexp": "^0.4.1",
     "hash.js": "^1.1.7",
     "html-to-text": "^9.0.5",
-    "htmlencode": "^0.0.4",
     "lowdb": "1",
     "lru-cache": "^10.0.1",
     "mkdirp": "^3.0.1",

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events";
-import { htmlEncode } from "htmlencode";
 import { htmlToText } from "html-to-text";
 import { LRUCache } from "lru-cache";
 
@@ -51,6 +50,19 @@ import { MatrixCapabilities } from "./models/Capabilities";
 import { PLManager, PowerLevelAction, PowerLevelBounds } from "./models/PowerLevels";
 import { CreateEvent, CreateEventContent } from "./models/events/CreateEvent";
 import { IJsonType, Json } from "./helpers/Types";
+
+// Encode plain text for inclusion in HTML. Replaces htmlencode@0.0.4, which
+// imports `util._extend` at module load on Node 22+ and emits a DEP0060
+// warning the consumer cannot suppress. Matrix only requires the five
+// special characters to be escaped; non-ASCII codepoints render fine as-is.
+function htmlEncode(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
 
 const SYNC_BACKOFF_MIN_MS = 5000;
 const SYNC_BACKOFF_MAX_MS = 15000;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,11 +3535,6 @@ html-to-text@^9.0.5:
     htmlparser2 "^8.0.2"
     selderee "^0.11.0"
 
-htmlencode@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/htmlencode/-/htmlencode-0.0.4.tgz#f7e2d6afbe18a87a78e63ba3308e753766740e3f"
-  integrity sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w==
-
 htmlparser2@^8.0.0, htmlparser2@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"


### PR DESCRIPTION
## Summary

Closes #84.

`htmlencode@0.0.4` is unmaintained (last released 2013) and imports `util._extend` at module load time. Starting with Node.js 22 that emits a `DEP0060` deprecation warning on every startup, fired *before* any consumer can install a `process.on("warning")` filter, so downstream bots see the warning printed to stderr unconditionally.

## Change

`htmlencode` is used in exactly two places (`MatrixClient.replyText` and `MatrixClient.replyNotice`) to HTML-escape a plain-text reply body. Replace the dependency with a four-line inline helper that escapes the five HTML special characters Matrix actually needs (`& < > " '`):

```ts
function htmlEncode(text: string): string {
    return text
        .replace(/&/g, "&amp;")
        .replace(/</g, "&lt;")
        .replace(/>/g, "&gt;")
        .replace(/"/g, "&quot;")
        .replace(/'/g, "&#39;");
}
```

Non-ASCII codepoints render natively in HTML5 so the long accented-character table that `htmlencode` shipped is unnecessary for Matrix's use case (a reply rendered inside an `m.text` event).

Removes the dependency from `package.json` and the corresponding lockfile entry.

## Test plan

- [x] `yarn build`, passes
- [x] `yarn lint`, passes
- [x] `yarn test --testPathPatterns MatrixClient`, 269 / 269 passing (covers `replyText` / `replyNotice`)
- [x] No remaining references to `htmlencode` in `src/`, `test/`, or `examples/`