### PR TITLE
Fixed documentation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TypeScript/JavaScript SDK for Matrix bots. For help and support, visit [#matrix-
 
 # Documentation
 
-Documentation for the project is available [here](https://turt2live.github.io/matrix-bot-sdk/index.html).
+Documentation for the project is available [here](https://element-hq.github.io/matrix-bot-sdk/).
 
 # Matrix version support
 


### PR DESCRIPTION
The documentation URL in the `README.md` file still linked to the original t2bot page.

Since I saw the workflows deploy the docs to [element-hq.github.io](https://element-hq.github.io/matrix-bot-sdk/), I've updated the link in the README file as well.

## Checklist

-  [x] Tests written for all new code
  - Not applicable
-  [x] Linter has been satisfied
  - Not applicable
-  [x] Sign-off given on the changes (see CONTRIBUTING.md)
  - `Signed-off-by: Balázs Vágvölgyi <balazs@vb2007.hu>`
