### PR TITLE
Updated package names and constructor usage reference in docs

### DIFF
--- a/docs/tutorials/bot.md
+++ b/docs/tutorials/bot.md
@@ -12,7 +12,7 @@ been made prior to deploying the bot. If you already have an access token, skip 
 **Registration**:
 
 ```typescript
-import { MatrixAuth } from "matrix-bot-sdk";
+import { MatrixAuth } from "@vector-im/matrix-bot-sdk";
 
 // This will be the URL where clients can reach your homeserver. Note that this might be different
 // from where the web/chat interface is hosted. The server must support password registration without
@@ -28,7 +28,7 @@ console.log("Copy this access token to your bot's config: ", client.accessToken)
 **Login** (preferred):
 
 ```typescript
-import { MatrixAuth } from "matrix-bot-sdk";
+import { MatrixAuth } from "@vector-im/matrix-bot-sdk";
 
 // This will be the URL where clients can reach your homeserver. Note that this might be different
 // from where the web/chat interface is hosted. The server must support password registration without
@@ -52,7 +52,7 @@ import {
     MatrixClient,
     SimpleFsStorageProvider,
     AutojoinRoomsMixin,
-} from "matrix-bot-sdk";
+} from "@vector-im/matrix-bot-sdk";
 
 // This will be the URL where clients can reach your homeserver. Note that this might be different
 // from where the web/chat interface is hosted. The server must support password registration without

--- a/docs/tutorials/encryption-bots.md
+++ b/docs/tutorials/encryption-bots.md
@@ -2,8 +2,11 @@ Setting up encryption for a bot is easy: simply provide a crypto storage provide
 providers and it'll start working behind the scenes.
 
 ```typescript
+import { RustSdkCryptoStorageProvider } from "@vector-im/matrix-bot-sdk";
+import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
+
 const storageProvider = new SimpleFsStorageProvider("./path/to/bot.json"); // or any other {@link IStorageProvider}
-const cryptoProvider = new RustSdkCryptoStorageProvider("./path/to/directory");
+const cryptoProvider = new RustSdkCryptoStorageProvider("./path/to/directory", StoreType.Sqlite); // use Sqlite for now, should be changed if large traffic's expected 
 
 // ⚠⚠ Be sure to back up both `./path/to/bot.json` and `./path/to/directory` when using this setup
 


### PR DESCRIPTION
While I was getting familiar with the SDK by reading through the docs, I noticed that:

- The package imports weren't updated after the fork
- The `RustSdkCryptoStorageProvider`'s constructor was updated to require a `StoreType` parameter as well

I've updated the `bot` and `encryption-bot` documentations accordingly.

## Checklist

* [x] Tests written for all new code
  - Not applicable
* [x] Linter has been satisfied
  - Not applicable
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
  - `Signed-off-by: Balázs Vágvölgyi <balazs@vb2007.hu>`